### PR TITLE
fix: read .templatesyncignore from template remote in GitLab sync

### DIFF
--- a/.gitlab/sync-template.yml
+++ b/.gitlab/sync-template.yml
@@ -29,16 +29,20 @@ template_sync:
       git remote add template "$FETCH_URL" || true
       git fetch template main
 
-      # Build include list from .templatesyncignore (whitelist: :! prefixed lines)
+      # Build include list from TEMPLATE's .templatesyncignore (whitelist: :! prefixed lines)
+      # Use template's version so newly added files are included in the same sync.
       INCLUDE=""
-      if [ -f .templatesyncignore ]; then
+      SYNCIGNORE=$(git show template/main:.templatesyncignore 2>/dev/null || cat .templatesyncignore 2>/dev/null || true)
+      if [ -n "$SYNCIGNORE" ]; then
         while IFS= read -r line || [ -n "$line" ]; do
           line=$(echo "$line" | sed 's/#.*//' | xargs)
           [ -z "$line" ] && continue
           case "$line" in
             :!*) INCLUDE="$INCLUDE ${line#:!}" ;;
           esac
-        done < .templatesyncignore
+        done <<EOF
+$SYNCIGNORE
+EOF
       fi
 
       if [ -z "$INCLUDE" ]; then


### PR DESCRIPTION
## Summary

- GitLab の template sync スクリプトがローカルの `.templatesyncignore` を読んでいたため、テンプレート側で新ファイル追加と `.templatesyncignore` 更新が同時に行われた場合、新ファイルが sync MR に含まれなかった
- `git show template/main:.templatesyncignore` でテンプレート側のホワイトリストを読むように修正

## Root Cause

`sync-template.yml` の include リスト構築がローカルの `.templatesyncignore` に依存していた。テンプレートで同時に追加された新ファイルはリストに含まれず、`.templatesyncignore` だけが更新される不整合な MR が生成されていた。

## Test plan

- [ ] GitLab Template Project で template_sync を手動トリガーし、新ファイルが MR に含まれることを確認
- [ ] `templatesyncignore_check` が通ることを確認