### PR TITLE
fix: avoid heredoc in sync-template.yml to prevent YAML parse error

### DIFF
--- a/.gitlab/sync-template.yml
+++ b/.gitlab/sync-template.yml
@@ -34,15 +34,7 @@ template_sync:
       INCLUDE=""
       SYNCIGNORE=$(git show template/main:.templatesyncignore 2>/dev/null || cat .templatesyncignore 2>/dev/null || true)
       if [ -n "$SYNCIGNORE" ]; then
-        while IFS= read -r line || [ -n "$line" ]; do
-          line=$(echo "$line" | sed 's/#.*//' | xargs)
-          [ -z "$line" ] && continue
-          case "$line" in
-            :!*) INCLUDE="$INCLUDE ${line#:!}" ;;
-          esac
-        done <<EOF
-$SYNCIGNORE
-EOF
+        INCLUDE=$(echo "$SYNCIGNORE" | sed 's/#.*//' | grep -E '^\s*:!' | sed 's/^\s*:!//' | xargs)
       fi
 
       if [ -z "$INCLUDE" ]; then


### PR DESCRIPTION
## Summary

- GitLab YAML パーサーが heredoc の `EOF` を YAML キーと誤認し、`sync-template.yml` のパースに失敗していた
- heredoc を `echo | sed | grep` のパイプに置き換え

## Root Cause

GitLab CI の block scalar (`- |`) 内で bash の heredoc (`<<EOF ... EOF`) を使うと、行頭の `EOF` が YAML の simple key として解釈されてパースエラーになる。

## Test plan

- [x] GitLab Template Project で template_sync をトリガーし、MR パイプラインが YAML エラーなく実行されることを確認