### PR TITLE
feat: add create-gitlab-project.sh for Free tier

### DIFF
--- a/docs/setup-gitlab.ja.md
+++ b/docs/setup-gitlab.ja.md
@@ -37,6 +37,8 @@ git push -u origin main
 
 > Instance レベルのテンプレートには管理者権限が必要で、GitLab.com では利用できません。すべての環境で Group テンプレートを推奨します。
 
+> **Free tier**: Group project templates は Premium 以上のプランが必要です。Free tier の場合はこの手順をスキップし、代わりに `scripts/create-gitlab-project.sh` を使用してください — 下記の[プロジェクトごと（Free Tier）](#プロジェクトごとfree-tier)を参照。
+
 ### 3. Template Project に Template Sync を設定
 
 Template Project は GitHub から同期して最新の状態を保ちます。この設定は **Template Project にのみ**行います — 個々の GAS プロジェクトには不要です。
@@ -75,6 +77,8 @@ git clone https://gitlab.yourcompany.com/<your-group>/<your-project>.git
 cd <your-project>
 pnpm install
 ```
+
+> **Free tier**: 「Create from template」が利用できない場合は、下記の [Free Tier](#プロジェクトごとfree-tier) ワークフローを使用してください。
 
 ### 2. Script ID の設定
 
@@ -136,6 +140,58 @@ pnpm run check    # lint + 型チェック + テスト
 | `template_sync` | `github.com`（デフォルト）または社内ミラー（`TEMPLATE_REPO_URL` 上書き時） |
 
 User Project の Runner は `github.com` への接続が不要です。外部アクセス（または社内ミラー）が必要なのは Template Project の Runner のみです。
+
+## プロジェクトごと（Free Tier）
+
+GitLab Free tier では「Create from template」（Group project templates）が利用できません。代わりに `scripts/create-gitlab-project.sh` を使用してプロジェクトを作成します。
+
+### 前提条件
+
+- [glab CLI](https://gitlab.com/gitlab-org/cli) が対象 GitLab ホストに認証済み
+- apps-script-fleet テンプレートリポジトリのローカルクローン
+
+### 1. プロジェクトの作成
+
+テンプレートリポジトリのルートから実行：
+
+```bash
+./scripts/create-gitlab-project.sh --group my-org --name my-gas-project
+```
+
+新しい GitLab リポジトリが作成され、テンプレートファイルがコピーされ、初回コミットが push されます。
+
+オプション：
+
+| フラグ            | 説明                                         | デフォルト       |
+| ----------------- | -------------------------------------------- | ---------------- |
+| `--group`         | GitLab group または namespace（必須）         |                  |
+| `--name`          | リポジトリ名（必須）                          |                  |
+| `--hostname`      | GitLab ホスト名                               | 自動検出         |
+| `--visibility`    | `private`、`internal`、`public`               | `private`        |
+| `--description`   | プロジェクトの説明                            |                  |
+
+### 2. GAS プロジェクトの初期化と CI/CD 設定
+
+```bash
+cd ../my-gas-project
+pnpm install
+./scripts/init.sh --title "My Script" [--gcp-project <NUMBER>]
+```
+
+### 3. Template Sync の設定
+
+1. **Project Access Token** を作成（Settings → Access Tokens、`write_repository` スコープ）
+2. CI/CD Variable として `GITLAB_PUSH_TOKEN` の名前で追加
+3. `TEMPLATE_REPO_URL` を CI/CD Variable として追加し、テンプレートリポジトリの git URL を指定（例: `https://gitlab.yourcompany.com/my-org/apps-script-fleet.git`）。または Group レベルで設定
+4. **Pipeline Schedule** を作成（CI/CD → Schedules）— 例: 毎週日曜
+
+### 4. 確認とデプロイ
+
+```bash
+pnpm run check    # lint + 型チェック + テスト
+```
+
+`dev` への push で dev 環境へ、`main` への push で本番環境へ自動デプロイされます。
 
 ## 既存環境からの移行
 

--- a/docs/setup-gitlab.md
+++ b/docs/setup-gitlab.md
@@ -37,6 +37,8 @@ Then register it as a **[Group project template](https://docs.gitlab.com/user/gr
 
 > Instance-level templates require admin privileges and are not available on GitLab.com. Group templates are recommended for all environments.
 
+> **Free tier**: Group project templates require Premium or higher. If you are on the Free tier, skip this step and use `scripts/create-gitlab-project.sh` instead — see [Per Project (Free Tier)](#per-project-free-tier) below.
+
 ### 3. Configure Template Sync on the Template Project
 
 The Template Project syncs from GitHub to stay up to date. Configure this on the **Template Project only** — individual GAS projects do not need this.
@@ -75,6 +77,8 @@ git clone https://gitlab.yourcompany.com/<your-group>/<your-project>.git
 cd <your-project>
 pnpm install
 ```
+
+> **Free tier**: If "Create from template" is not available, use the [Free Tier](#per-project-free-tier) workflow below instead.
 
 ### 2. Set your script IDs
 
@@ -136,6 +140,58 @@ Push to `dev` triggers dev deployment, push to `main` triggers production deploy
 | `template_sync` | `github.com` (default) or internal mirror (if `TEMPLATE_REPO_URL` overridden) |
 
 User Project runners never need to reach `github.com`. Only the Template Project's runner needs external access (or an internal mirror).
+
+## Per Project (Free Tier)
+
+On GitLab Free tier, "Create from template" (Group project templates) is not available. Use `scripts/create-gitlab-project.sh` to create projects from the template instead.
+
+### Prerequisites
+
+- [glab CLI](https://gitlab.com/gitlab-org/cli) authenticated for your GitLab host
+- A local clone of the apps-script-fleet template repository
+
+### 1. Create the project
+
+From the template repository root:
+
+```bash
+./scripts/create-gitlab-project.sh --group my-org --name my-gas-project
+```
+
+This creates a new GitLab repository, copies template files, and pushes the initial commit.
+
+Options:
+
+| Flag              | Description                                         | Default         |
+| ----------------- | --------------------------------------------------- | --------------- |
+| `--group`         | GitLab group or namespace (required)                |                 |
+| `--name`          | Repository name (required)                          |                 |
+| `--hostname`      | GitLab hostname                                     | auto-detect     |
+| `--visibility`    | `private`, `internal`, or `public`                  | `private`       |
+| `--description`   | Project description                                 |                 |
+
+### 2. Initialize GAS projects and CI/CD
+
+```bash
+cd ../my-gas-project
+pnpm install
+./scripts/init.sh --title "My Script" [--gcp-project <NUMBER>]
+```
+
+### 3. Set up Template Sync
+
+1. Create a **Project Access Token** (Settings → Access Tokens) with `write_repository` scope
+2. Add it as a CI/CD Variable named `GITLAB_PUSH_TOKEN`
+3. Add `TEMPLATE_REPO_URL` as a CI/CD Variable pointing to the template repository's git URL (e.g., `https://gitlab.yourcompany.com/my-org/apps-script-fleet.git`), or set it at the Group level for all projects
+4. Create a **Pipeline Schedule** (CI/CD → Schedules) — e.g., weekly on Sunday
+
+### 4. Verify and deploy
+
+```bash
+pnpm run check    # lint + typecheck + test
+```
+
+Push to `dev` triggers dev deployment, push to `main` triggers production deployment.
 
 ## Migration from Existing Setup
 

--- a/scripts/create-gitlab-project.sh
+++ b/scripts/create-gitlab-project.sh
@@ -117,6 +117,7 @@ esac
 
 require_cmd glab
 require_cmd git
+require_cmd node
 
 # Detect hostname from glab auth if not specified
 if [[ -z "$HOSTNAME" ]]; then
@@ -251,7 +252,7 @@ git commit -m "Initial commit from apps-script-fleet template" --quiet
 
 # Use glab-compatible auth for push
 PUSH_URL=$(echo "$CLONE_URL" | sed "s|https://|https://oauth2:$(glab auth token --hostname "$HOSTNAME")@|")
-git push -u "$PUSH_URL" main --quiet 2>&1
+git push -u "$PUSH_URL" main --quiet 2>/dev/null || die "Failed to push to GitLab. Check your glab authentication."
 
 # Replace remote URL with clean version (no token)
 git remote set-url origin "$CLONE_URL"

--- a/scripts/create-gitlab-project.sh
+++ b/scripts/create-gitlab-project.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apps Script Fleet — Create GitLab Project (Free Tier)
+#
+# Creates a new GitLab repository from this template.
+# Use this instead of "Create from template" on GitLab Free tier.
+#
+# Prerequisites:
+#   - glab CLI authenticated for the target GitLab host
+#   - Run from the root of the apps-script-fleet template repo
+#
+# Usage:
+#   ./scripts/create-gitlab-project.sh --group <namespace> --name <project-name> [options]
+#
+# After creation, cd into the new project and run init.sh:
+#   cd ../<project-name>
+#   ./scripts/init.sh --title "My Script" [--gcp-project <NUMBER>]
+
+GROUP=""
+PROJECT_NAME=""
+HOSTNAME=""
+VISIBILITY="private"
+DESCRIPTION=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --group <namespace> --name <project-name> [options]
+
+Create a new GitLab repository from the Apps Script Fleet template.
+
+Required:
+  --group <namespace>       GitLab group or namespace (e.g., my-org, my-org/sub-group)
+  --name <project-name>     Repository name (e.g., slack-notifier)
+
+Options:
+  --hostname <host>         GitLab hostname (default: auto-detect from glab auth)
+  --visibility <level>      private (default), internal, or public
+  --description <text>      Project description
+  --help                    Show this help
+
+Example:
+  $0 --group my-org --name slack-notifier
+  $0 --group my-org --name form-mailer --visibility internal --description "Contact form mailer"
+
+After creation:
+  cd ../<project-name>
+  ./scripts/init.sh --title "My Script" --gcp-project 123456789
+EOF
+  exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --group)
+      GROUP="$2"
+      shift 2
+      ;;
+    --name)
+      PROJECT_NAME="$2"
+      shift 2
+      ;;
+    --hostname)
+      HOSTNAME="$2"
+      shift 2
+      ;;
+    --visibility)
+      VISIBILITY="$2"
+      shift 2
+      ;;
+    --description)
+      DESCRIPTION="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Run '$0 --help' for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed."
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+[[ -n "$GROUP" ]] || die "--group is required. Run '$0 --help' for usage."
+[[ -n "$PROJECT_NAME" ]] || die "--name is required. Run '$0 --help' for usage."
+
+case "$VISIBILITY" in
+  private|internal|public) ;;
+  *) die "Invalid --visibility '$VISIBILITY'. Must be: private, internal, or public." ;;
+esac
+
+# Must be run from the template repo root
+[[ -f ".templatesyncignore" ]] || die "Must be run from the apps-script-fleet template repository root."
+
+require_cmd glab
+require_cmd git
+
+# Detect hostname from glab auth if not specified
+if [[ -z "$HOSTNAME" ]]; then
+  HOSTNAME=$(glab auth status 2>&1 | grep -m1 "Logged in to" | sed 's/.*Logged in to //' | sed 's/ .*//' | tr -d '[:space:]') || true
+  [[ -n "$HOSTNAME" ]] || die "Could not detect GitLab hostname. Specify --hostname or run 'glab auth login'."
+fi
+
+# Verify glab is authenticated for the target host
+if ! glab auth status --hostname "$HOSTNAME" >/dev/null 2>&1; then
+  die "glab is not authenticated for $HOSTNAME. Run 'glab auth login --hostname $HOSTNAME'."
+fi
+
+# Check destination directory doesn't already exist
+DEST_DIR="../${PROJECT_NAME}"
+if [[ -d "$DEST_DIR" ]]; then
+  die "Directory '$DEST_DIR' already exists. Remove it or choose a different --name."
+fi
+
+echo "=== Apps Script Fleet — Create GitLab Project ==="
+echo ""
+echo "  Host:       ${HOSTNAME}"
+echo "  Group:      ${GROUP}"
+echo "  Name:       ${PROJECT_NAME}"
+echo "  Visibility: ${VISIBILITY}"
+[[ -n "$DESCRIPTION" ]] && echo "  Description: ${DESCRIPTION}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 1: Create GitLab project
+# ---------------------------------------------------------------------------
+
+echo "Creating GitLab project..."
+
+CREATE_ARGS=(api -X POST "projects"
+  --hostname "$HOSTNAME"
+  --raw-field "name=${PROJECT_NAME}"
+  --raw-field "path=${PROJECT_NAME}"
+  --raw-field "namespace_path=${GROUP}"
+  --raw-field "visibility=${VISIBILITY}"
+  --raw-field "initialize_with_readme=false"
+)
+
+if [[ -n "$DESCRIPTION" ]]; then
+  CREATE_ARGS+=(--raw-field "description=${DESCRIPTION}")
+fi
+
+CREATE_RESULT=$(glab "${CREATE_ARGS[@]}" 2>&1) || die "Failed to create project: ${CREATE_RESULT}"
+
+# Extract clone URL
+CLONE_URL=$(echo "$CREATE_RESULT" | node -e "
+  const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+  process.stdout.write(data.http_url_to_clone || '');
+")
+
+[[ -n "$CLONE_URL" ]] || die "Could not extract clone URL from API response."
+
+echo "  Created: ${CLONE_URL}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 2: Copy template files to new project
+# ---------------------------------------------------------------------------
+
+echo "Scaffolding project files..."
+
+mkdir -p "$DEST_DIR"
+
+# Files to copy: everything tracked in git EXCEPT template-repo-only files
+# Exclude: docs/ (images, setup guides — will be available via template sync),
+#          README.md/README.ja.md (user should write their own),
+#          CONTRIBUTING.md (template-repo-only),
+#          .github/workflows/publish.yml (template-repo-only),
+#          docs/superpowers/ (design docs),
+#          scripts/create-gitlab-project.sh (this script, template-repo-only)
+EXCLUDE_PATTERNS=(
+  "^docs/"
+  "^README\\.md$"
+  "^README\\.ja\\.md$"
+  "^CONTRIBUTING\\.md$"
+  "^\\.github/workflows/publish\\.yml$"
+  "^\\.claude/"
+  "^scripts/create-gitlab-project\\.sh$"
+)
+
+# Build grep exclude pattern
+EXCLUDE_REGEX=$(printf "%s\n" "${EXCLUDE_PATTERNS[@]}" | paste -sd'|' -)
+
+# Get list of files to copy
+FILES=$(git ls-files | grep -Ev "$EXCLUDE_REGEX")
+
+# Copy files preserving directory structure
+while IFS= read -r file; do
+  dest_file="${DEST_DIR}/${file}"
+  dest_subdir=$(dirname "$dest_file")
+  mkdir -p "$dest_subdir"
+  cp "$file" "$dest_file"
+done <<< "$FILES"
+
+# Create a minimal README for the new project
+cat > "${DEST_DIR}/README.md" <<EOF
+# ${PROJECT_NAME}
+
+Built with [Apps Script Fleet](https://github.com/h13/apps-script-fleet).
+
+## Development
+
+\`\`\`bash
+pnpm install
+pnpm run check    # lint + typecheck + test
+pnpm run deploy   # deploy to dev
+\`\`\`
+
+## Setup
+
+See the [setup guide](https://github.com/h13/apps-script-fleet/blob/main/docs/setup-gitlab.md) for CI/CD configuration.
+EOF
+
+echo "  Copied $(echo "$FILES" | wc -l | tr -d ' ') files"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 3: Initialize git and push
+# ---------------------------------------------------------------------------
+
+echo "Pushing to GitLab..."
+
+cd "$DEST_DIR"
+git init -b main
+git remote add origin "$CLONE_URL"
+git add -A
+git commit -m "Initial commit from apps-script-fleet template" --quiet
+
+# Use glab-compatible auth for push
+PUSH_URL=$(echo "$CLONE_URL" | sed "s|https://|https://oauth2:$(glab auth token --hostname "$HOSTNAME")@|")
+git push -u "$PUSH_URL" main --quiet 2>&1
+
+# Replace remote URL with clean version (no token)
+git remote set-url origin "$CLONE_URL"
+
+echo "  Pushed to: ${CLONE_URL}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+echo "Done!"
+echo ""
+echo "  cd ../${PROJECT_NAME}"
+echo "  pnpm install"
+echo "  ./scripts/init.sh --title \"${PROJECT_NAME}\" [--gcp-project <NUMBER>]"
+echo ""
+echo "  Project URL: https://${HOSTNAME}/${GROUP}/${PROJECT_NAME}"

--- a/scripts/create-gitlab-project.sh
+++ b/scripts/create-gitlab-project.sh
@@ -151,11 +151,20 @@ echo ""
 
 echo "Creating GitLab project..."
 
+# Resolve namespace path to numeric ID (GitLab API requires namespace_id)
+ENCODED_GROUP=$(echo "$GROUP" | sed 's|/|%2F|g')
+NAMESPACE_ID=$(glab api "namespaces/${ENCODED_GROUP}" --hostname "$HOSTNAME" 2>/dev/null \
+  | node -e "
+    const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+    process.stdout.write(String(data.id || ''));
+  ") || true
+[[ -n "$NAMESPACE_ID" ]] || die "Could not find namespace '${GROUP}' on ${HOSTNAME}. Check the group path."
+
 CREATE_ARGS=(api -X POST "projects"
   --hostname "$HOSTNAME"
   --raw-field "name=${PROJECT_NAME}"
   --raw-field "path=${PROJECT_NAME}"
-  --raw-field "namespace_path=${GROUP}"
+  --raw-field "namespace_id=${NAMESPACE_ID}"
   --raw-field "visibility=${VISIBILITY}"
   --raw-field "initialize_with_readme=false"
 )


### PR DESCRIPTION
## Summary

Add `scripts/create-gitlab-project.sh` — a script that creates a new GitLab repository from this template without requiring Premium tier.

GitLab Free tier does not support Group project templates ("Create from template"). This script provides an equivalent workflow using the `glab` CLI.

## What it does

1. Creates a new GitLab project via `glab api`
2. Copies template files (excluding template-repo-only files like docs/, README, publish.yml)
3. Generates a minimal README for the new project
4. Pushes the initial commit

## Usage

```bash
# From the template repo root
./scripts/create-gitlab-project.sh --group my-org --name slack-notifier

# Then initialize GAS projects
cd ../slack-notifier
pnpm install
./scripts/init.sh --title "Slack Notifier"
```

## Documentation

- Updated `docs/setup-gitlab.md` with a "Per Project (Free Tier)" section
- Updated `docs/setup-gitlab.ja.md` with Japanese translation
- Added notes in existing Premium-tier instructions pointing to the Free tier alternative

## Design decisions

- **Separate from init.sh**: Repo creation and GAS project setup are different responsibilities. Keeping them separate allows re-running either independently.
- **Not synced to downstream**: This script is not in `.templatesyncignore`, so it only exists in the template repo itself.
- **Minimal README**: New projects get a stub README rather than the template's full README.