### PR TITLE
feat: clasp認証情報のSecret Manager + WIF移行

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,9 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       !github.event.repository.is_template
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ github.event.workflow_run.head_branch == 'main' && 'production' || 'development' }}
     concurrency:
       group: deploy-${{ github.event.workflow_run.head_branch }}
@@ -42,13 +45,49 @@ jobs:
         env:
           DEPLOY_ENV: ${{ github.event.workflow_run.head_branch == 'main' && 'production' || 'development' }}
 
+      # Secret Manager mode: direct WIF (no service-account impersonation).
+      # Requires org variables GCP_WIF_PROVIDER + CLASPRC_SECRET (docs/secret-manager.md).
+      - name: Authenticate to Google Cloud (WIF)
+        if: vars.GCP_WIF_PROVIDER != ''
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+
+      - name: Fetch clasp credentials from Secret Manager
+        if: vars.GCP_WIF_PROVIDER != ''
+        id: gcp-secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
+        with:
+          secrets: |-
+            clasprc:${{ vars.CLASPRC_SECRET }}
+
       - name: Setup clasp credentials
         env:
-          CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
+          WIF_ENABLED: ${{ vars.GCP_WIF_PROVIDER != '' }}
+          CLASPRC_GCP: ${{ steps.gcp-secrets.outputs.clasprc }}
+          CLASPRC_LEGACY: ${{ secrets.CLASPRC_JSON }}
           CLASP_JSON: ${{ secrets.CLASP_JSON }}
         run: |
+          if [ "$WIF_ENABLED" = "true" ]; then
+            # Secret Manager mode: never fall back to the legacy secret silently.
+            CLASPRC="$CLASPRC_GCP"
+            if [ -z "$CLASPRC" ]; then
+              echo "::error::GCP_WIF_PROVIDER is set but Secret Manager returned an empty payload. Check CLASPRC_SECRET and the secret's latest version."
+              exit 1
+            fi
+          else
+            CLASPRC="$CLASPRC_LEGACY"
+            if [ -z "$CLASPRC" ]; then
+              echo "::error::No clasp credentials. Set org variables GCP_WIF_PROVIDER + CLASPRC_SECRET (Secret Manager), or org secret CLASPRC_JSON (legacy)."
+              exit 1
+            fi
+          fi
+          if [ -z "$CLASP_JSON" ]; then
+            echo "::error::CLASP_JSON secret is not set for this environment."
+            exit 1
+          fi
           umask 077
-          printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
+          printf '%s' "$CLASPRC" > ~/.clasprc.json
           printf '%s' "$CLASP_JSON" > .clasp.json
 
       - name: Push to GAS

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,9 +43,13 @@ jobs:
           DEPLOY_ENV: ${{ github.event.workflow_run.head_branch == 'main' && 'production' || 'development' }}
 
       - name: Setup clasp credentials
+        env:
+          CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
+          CLASP_JSON: ${{ secrets.CLASP_JSON }}
         run: |
-          echo '${{ secrets.CLASPRC_JSON }}' > ~/.clasprc.json
-          echo '${{ secrets.CLASP_JSON }}' > .clasp.json
+          umask 077
+          printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
+          printf '%s' "$CLASP_JSON" > .clasp.json
 
       - name: Push to GAS
         run: pnpm exec clasp push -f

--- a/.gitlab/cd.yml
+++ b/.gitlab/cd.yml
@@ -9,8 +9,10 @@
     - pnpm install --frozen-lockfile
   script:
     - pnpm run build
-    - echo "$CLASPRC_JSON" > ~/.clasprc.json
-    - echo "$CLASP_JSON" > .clasp.json
+    - |
+      umask 077
+      printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
+      printf '%s' "$CLASP_JSON" > .clasp.json
     - pnpm exec clasp push -f
     - pnpm exec clasp deploy -i "$DEPLOYMENT_ID" --description "GitLab CD from $CI_COMMIT_REF_NAME@$CI_COMMIT_SHORT_SHA"
     - |

--- a/.gitlab/cd.yml
+++ b/.gitlab/cd.yml
@@ -3,15 +3,30 @@
 .deploy_base:
   stage: deploy
   image: node:24@sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
+  # aud must match the WIF provider's --allowed-audiences (GitLab >= 16.1).
+  id_tokens:
+    GCP_OIDC_TOKEN:
+      aud: $CI_SERVER_URL
   before_script:
     - corepack enable
     - pnpm config set store-dir .pnpm-store
     - pnpm install --frozen-lockfile
   script:
     - pnpm run build
+    # Dual-mode credentials: GCP_WIF_PROVIDER set → Secret Manager (no silent
+    # fallback); unset → legacy CLASPRC_JSON; neither → explicit error.
+    # See docs/secret-manager.md.
     - |
       umask 077
-      printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
+      if [[ -n "${GCP_WIF_PROVIDER:-}" ]]; then
+        [[ -n "${CLASPRC_SECRET:-}" ]] || { echo "Error: GCP_WIF_PROVIDER is set but CLASPRC_SECRET is not." >&2; exit 1; }
+        ./scripts/gcp-get-secret.sh "$CLASPRC_SECRET" > ~/.clasprc.json
+      elif [[ -n "${CLASPRC_JSON:-}" ]]; then
+        printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
+      else
+        echo "Error: no clasp credentials. Set group variables GCP_WIF_PROVIDER + CLASPRC_SECRET (Secret Manager), or CLASPRC_JSON (legacy)." >&2
+        exit 1
+      fi
       printf '%s' "$CLASP_JSON" > .clasp.json
     - pnpm exec clasp push -f
     - pnpm exec clasp deploy -i "$DEPLOYMENT_ID" --description "GitLab CD from $CI_COMMIT_REF_NAME@$CI_COMMIT_SHORT_SHA"

--- a/.gitlab/post-deploy.yml.example
+++ b/.gitlab/post-deploy.yml.example
@@ -11,14 +11,27 @@
 post_deploy:
   stage: deploy
   image: node:24@sha256:3a09aa6354567619221ef6c45a5051b671f953f0a1924d1f819ffb236e520e6b
+  # aud must match the WIF provider's --allowed-audiences (GitLab >= 16.1).
+  id_tokens:
+    GCP_OIDC_TOKEN:
+      aud: $CI_SERVER_URL
   before_script:
     - corepack enable
     - pnpm config set store-dir .pnpm-store
     - pnpm install --frozen-lockfile
   script:
+    # Dual-mode credentials — same rules as .deploy_base (docs/secret-manager.md).
     - |
       umask 077
-      printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
+      if [[ -n "${GCP_WIF_PROVIDER:-}" ]]; then
+        [[ -n "${CLASPRC_SECRET:-}" ]] || { echo "Error: GCP_WIF_PROVIDER is set but CLASPRC_SECRET is not." >&2; exit 1; }
+        ./scripts/gcp-get-secret.sh "$CLASPRC_SECRET" > ~/.clasprc.json
+      elif [[ -n "${CLASPRC_JSON:-}" ]]; then
+        printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
+      else
+        echo "Error: no clasp credentials. Set group variables GCP_WIF_PROVIDER + CLASPRC_SECRET (Secret Manager), or CLASPRC_JSON (legacy)." >&2
+        exit 1
+      fi
       printf '%s' "$CLASP_JSON" > .clasp.json
     - ./scripts/set-properties.sh --env SCRIPT_PROPERTIES
   rules:

--- a/.gitlab/post-deploy.yml.example
+++ b/.gitlab/post-deploy.yml.example
@@ -16,8 +16,10 @@ post_deploy:
     - pnpm config set store-dir .pnpm-store
     - pnpm install --frozen-lockfile
   script:
-    - echo "$CLASPRC_JSON" > ~/.clasprc.json
-    - echo "$CLASP_JSON" > .clasp.json
+    - |
+      umask 077
+      printf '%s' "$CLASPRC_JSON" > ~/.clasprc.json
+      printf '%s' "$CLASP_JSON" > .clasp.json
     - ./scripts/set-properties.sh --env SCRIPT_PROPERTIES
   rules:
     - if: $SCRIPT_PROPERTIES && $GCP_PROJECT_NUMBER

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -41,6 +41,8 @@
 :!docs/setup-github.ja.md
 :!docs/setup-gitlab.md
 :!docs/setup-gitlab.ja.md
+:!docs/secret-manager.md
+:!docs/secret-manager.ja.md
 
 # Scripts
 :!scripts/init.sh

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -45,6 +45,7 @@
 # Scripts
 :!scripts/init.sh
 :!scripts/set-properties.sh
+:!scripts/gcp-get-secret.sh
 
 # Hook examples
 :!.github/hooks/post-deploy.sh.example

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -46,6 +46,7 @@
 :!scripts/init.sh
 :!scripts/set-properties.sh
 :!scripts/gcp-get-secret.sh
+:!scripts/fetch-clasp-credentials.sh
 
 # Hook examples
 :!.github/hooks/post-deploy.sh.example

--- a/README.ja.md
+++ b/README.ja.md
@@ -69,30 +69,38 @@ Apps Script Fleet は各 GAS 機能を独立したリポジトリとして扱い
 | フロントエンド開発 | Vite + Alpine.js + Tailwind                                                  | 基本的な HTML（GAS 組み込み）                    |
 | テスト             | Vitest（任意）                                                               | Jest（80% カバレッジ必須）                       |
 | テンプレート同期   | —                                                                            | 週次（自動 PR）                                  |
-| 組織レベルの認証   | —                                                                            | CLASPRC_JSON 共有シークレット（GitHub + GitLab） |
+| 組織レベルの認証   | —                                                                            | Secret Manager + WIF、キーレス CI（GitHub + GitLab） |
 
 > リッチな UI をクライアントサイドフレームワークで構築する場合は、[Apps Script Engine](https://github.com/WildH0g/apps-script-engine-template) が適しています。
 > 組織全体で 5 つ以上の小さな GAS 自動化を管理する場合は、Apps Script Fleet の出番です。
 
 ## 組織セットアップ（初回のみ）
 
-チームが Apps Script Fleet を使い始める前に、組織の管理者が clasp の共有認証情報をセットアップします：
+チームが Apps Script Fleet を使い始める前に、組織の管理者が clasp の共有認証情報を **Google Cloud Secret Manager** に格納します。CI は **Workload Identity Federation (OIDC)** でキーレス取得、開発者は個人の `gcloud` ログインで取得します。secret 1つ + WIF プール1つ + org/group 単位 IAM = **リポごとの認証設定ゼロ**。旧方式には無かったローテーション・失効・監査ログが手に入ります。
 
-1. **clasp にログイン**（CI/CD デプロイに使う Google アカウントで）：
+詳細な手順: **[docs/secret-manager.ja.md](docs/secret-manager.ja.md)**。概要:
 
-   ```bash
-   npx @google/clasp login
-   ```
+1. **認証情報の格納**: デプロイ用アカウントで `clasp login` → `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`
+2. **WIF プール `gas-fleet` を作成**し、`github` / `gitlab` プロバイダを org/group に attribute 制限
+3. **`roles/secretmanager.secretAccessor` を付与**: CI の `principalSet://` と開発者 Google グループへ
+4. **org/group の CI 変数** `GCP_WIF_PROVIDER` + `CLASPRC_SECRET` を設定（両プラットフォーム同名）
+5. **各開発者**はマシンごとに1回 `./scripts/fetch-clasp-credentials.sh` を実行 — `~/.clasprc.json` は全リポで共有されます
 
-   `~/.clasprc.json` が生成されます。
+> **clasp の認証そのものは変わりません。** clasp は今後も `~/.clasprc.json` の OAuth トークンを使います（Apps Script API は push/deploy にサービスアカウント非対応）。変わるのはトークンの保管場所と配送経路だけです。
 
-2. **組織のパスワードマネージャーに保存** — `~/.clasprc.json` の内容を共有クレデンシャルとして登録します（例: 「clasp CI/CD — GAS Fleet」）。
+<details>
+<summary><strong>Legacy / エアギャップ向けフォールバック: <code>CLASPRC_JSON</code> 共有シークレット</strong></summary>
 
-3. **`CLASPRC_JSON` を組織レベルの CI/CD シークレットに設定**：
+エアギャップ GitLab（`sts.googleapis.com` / `secretmanager.googleapis.com` への egress が無い環境）向け。`GCP_WIF_PROVIDER` 未設定時、CI は自動的にこちらを使います:
+
+1. **clasp にログイン**（CI/CD 用 Google アカウントで）: `npx @google/clasp login` → `~/.clasprc.json` が生成されます
+2. **組織のパスワードマネージャーに保存** — `~/.clasprc.json` の内容を共有クレデンシャルとして登録（例: 「clasp CI/CD — GAS Fleet」）
+3. **`CLASPRC_JSON` を組織レベルの CI/CD シークレットに設定**:
    - **GitHub**: [Organization secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-organization) → `CLASPRC_JSON` を追加（値は JSON 全体）
    - **GitLab**: グループ → Settings → CI/CD → Variables → `CLASPRC_JSON` を追加（protected, masked）
+4. **各開発者**はパスワードマネージャーから `~/.clasprc.json` をローカルマシンにコピー
 
-4. **各開発者**はパスワードマネージャーから `~/.clasprc.json` をローカルマシンにコピーします。
+</details>
 
 ### GCP プロジェクトの設定（任意、推奨）
 

--- a/README.md
+++ b/README.md
@@ -69,30 +69,38 @@ The result — your day looks like this:
 | Frontend dev   | Vite + Alpine.js + Tailwind                                                  | Basic HTML (Apps Script built-in)            |
 | Testing        | Vitest (optional)                                                            | Jest (80% coverage enforced)                 |
 | Template sync  | —                                                                            | Weekly (auto-PR)                             |
-| Org-level auth | —                                                                            | CLASPRC_JSON shared secret (GitHub + GitLab) |
+| Org-level auth | —                                                                            | Secret Manager + WIF, keyless CI (GitHub + GitLab) |
 
 > Building a rich UI with client-side frameworks? [Apps Script Engine](https://github.com/WildH0g/apps-script-engine-template) is the better fit.
 > Managing 5+ small Apps Script automations across your org? That's what Apps Script Fleet is for.
 
 ## Organization Setup (One-Time)
 
-Before your team can use Apps Script Fleet, an org admin needs to set up shared clasp credentials:
+Before your team can use Apps Script Fleet, an org admin stores the shared clasp credentials in **Google Cloud Secret Manager**. CI fetches them keylessly via **Workload Identity Federation (OIDC)**; developers fetch them with their personal `gcloud` login. One secret + one WIF pool + org/group-wide IAM = **zero per-repo auth setup**, with rotation, revocation, and audit logs the legacy model never had.
 
-1. **Login to clasp** with the Google account that will own CI/CD deployments:
+Full step-by-step guide: **[docs/secret-manager.md](docs/secret-manager.md)**. In outline:
 
-   ```bash
-   npx @google/clasp login
-   ```
+1. **Store credentials**: `clasp login` with the deploy account → `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`
+2. **Create WIF pool `gas-fleet`** with `github` / `gitlab` providers, attribute-restricted to your org/group
+3. **Grant `roles/secretmanager.secretAccessor`** to the CI `principalSet://` and to the developer Google group
+4. **Set org/group CI variables** `GCP_WIF_PROVIDER` + `CLASPRC_SECRET` (same names on both platforms)
+5. **Each developer** runs `./scripts/fetch-clasp-credentials.sh` once per machine — `~/.clasprc.json` is shared by every repo
 
-   This generates `~/.clasprc.json`.
+> **clasp auth itself is unchanged.** clasp still uses the `~/.clasprc.json` OAuth token (the Apps Script API does not support service accounts for push/deploy). Only the storage and delivery of that token change.
 
-2. **Save to your org's password manager** — share the contents of `~/.clasprc.json` as a shared credential entry (e.g., "clasp CI/CD — GAS Fleet").
+<details>
+<summary><strong>Legacy / air-gapped fallback: <code>CLASPRC_JSON</code> shared secret</strong></summary>
 
+For air-gapped GitLab instances (no egress to `sts.googleapis.com` / `secretmanager.googleapis.com`). CI uses this automatically when `GCP_WIF_PROVIDER` is not set:
+
+1. **Login to clasp** with the CI/CD Google account: `npx @google/clasp login` → generates `~/.clasprc.json`
+2. **Save to your org's password manager** — share the contents as a shared credential entry (e.g., "clasp CI/CD — GAS Fleet")
 3. **Set `CLASPRC_JSON` as an org-level CI/CD secret**:
    - **GitHub**: [Organization secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-organization) → add `CLASPRC_JSON` with the full JSON content
    - **GitLab**: Group → Settings → CI/CD → Variables → add `CLASPRC_JSON` (protected, masked)
+4. **Each developer** copies `~/.clasprc.json` from the password manager to their local machine
 
-4. **Each developer** copies `~/.clasprc.json` from the password manager to their local machine.
+</details>
 
 ### GCP Project Setup (Optional, Recommended)
 

--- a/docs/secret-manager.ja.md
+++ b/docs/secret-manager.ja.md
@@ -1,0 +1,237 @@
+# Secret Manager + Workload Identity Federation による clasp 認証情報管理
+
+[English](secret-manager.md)
+
+フリートの認証情報アーキテクチャの single source of truth です。従来の「org
+secret + パスワードマネージャー」による `CLASPRC_JSON` 配布を置き換えます。
+
+## アーキテクチャ
+
+**clasp の認証そのものは変わりません。** clasp は今後も `clasp login` が生成する
+`~/.clasprc.json`(ユーザー OAuth リフレッシュトークン)を使います — Apps
+Script API はスクリプトの push/deploy にサービスアカウントを許可していないため、
+GCP ネイティブ認証への置き換えは不可能です。変わるのはトークンの**保管場所**
+(Secret Manager)と**配送経路**(CI は WIF、開発者は個人 gcloud)だけです。
+
+認証は二段構えになります:
+
+1. **Secret Manager から `.clasprc.json` を取り出すための認証** — WIF(CI)/
+   個人 gcloud(開発者)。IAM によるスコープ制御・監査ログ・ローテーションが
+   効くのはこの層です。
+2. **clasp が GAS へデプロイするための認証** — 取り出した `.clasprc.json`
+   (従来どおり・据え置き)。
+
+すべて中央集約されており、**リポ単位のセットアップ作業はゼロ**です:
+
+| リソース | 個数 | スコープ |
+| --- | --- | --- |
+| Secret `clasp-credentials` | 1 | 中央 GCP プロジェクト。CI は常に `latest` を読む |
+| WIF プール `gas-fleet` | 1 | 配下にプロバイダ `github` + `gitlab` |
+| IAM バインディング | org/group 単位 | `principalSet://…/attribute.repository_owner/<org>`(GitHub)/ `attribute.namespace_path/<group>`(GitLab) |
+| CI 変数 `GCP_WIF_PROVIDER`, `CLASPRC_SECRET` | org/group レベル | 全リポに自動継承 |
+
+**直接 WIF(サービスアカウント偽装なし)** を採用しています。Secret Manager は
+フェデレーテッドトークンを直接受け付けるため、プールの `principalSet://` に
+`roles/secretmanager.secretAccessor` を直付与でき、中間サービスアカウントが
+不要です。監査ログにはアクセスごとに `attribute.repository` / `project_path`
+が記録されます。
+
+### デュアルモード規則(両 CI プラットフォーム共通)
+
+- `GCP_WIF_PROVIDER` が設定済み → Secret Manager 経路。取得失敗は**ジョブ失敗**
+  — legacy secret へのサイレントフォールバックはしません。
+- `GCP_WIF_PROVIDER` 未設定 → legacy `CLASPRC_JSON`(エアギャップ GitLab 用に
+  存続)。
+- どちらも無し → 明示エラー。
+
+## 一度きりの組織セットアップ
+
+コマンドはすべて中央 GCP プロジェクト(Cloud Logging / `clasp run` と同じもの)
+に対して実行します。課金の有効化が前提です。
+
+```bash
+PROJECT_ID=your-central-project        # 英数字のプロジェクト ID
+ORG=your-github-org                    # GitHub organization
+GROUP=your-gitlab-group                # GitLab トップレベルグループ
+GITLAB_URL=https://gitlab.example.com  # または https://gitlab.com
+gcloud config set project "$PROJECT_ID"
+PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+
+# 0. API の有効化
+gcloud services enable secretmanager.googleapis.com sts.googleapis.com iam.googleapis.com
+```
+
+### 1. secret の作成
+
+デプロイ専用 Google アカウント(例: `gas-deploy@yourcompany.com`)で:
+
+```bash
+npx @google/clasp login            # ~/.clasprc.json を生成
+gcloud secrets create clasp-credentials --replication-policy=automatic
+gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"
+```
+
+### 2. WIF プールの作成
+
+```bash
+gcloud iam workload-identity-pools create gas-fleet \
+  --location=global --display-name="GAS Fleet CI"
+```
+
+### 3a. GitHub プロバイダ
+
+attribute condition は**必須**です: `token.actions.githubusercontent.com` は
+全 GitHub org が共有するマルチテナント issuer のためです。
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc github \
+  --location=global --workload-identity-pool=gas-fleet \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner == '${ORG}'"
+```
+
+### 3b. GitLab プロバイダ
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc gitlab \
+  --location=global --workload-identity-pool=gas-fleet \
+  --issuer-uri="${GITLAB_URL}" \
+  --allowed-audiences="${GITLAB_URL}" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.project_path=assertion.project_path,attribute.namespace_path=assertion.namespace_path" \
+  --attribute-condition="assertion.namespace_path == '${GROUP}' || assertion.namespace_path.startsWith('${GROUP}/')"
+```
+
+`--allowed-audiences` は CI の JWT の `aud` と一致する必要があります。テンプレは
+`$CI_SERVER_URL`(スキーム込み・末尾スラッシュ無し)を設定します。
+
+### 4. CI へのアクセス付与(org/group 単位)
+
+```bash
+POOL="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/gas-fleet"
+
+gcloud secrets add-iam-policy-binding clasp-credentials \
+  --role=roles/secretmanager.secretAccessor \
+  --member="principalSet://iam.googleapis.com/${POOL}/attribute.repository_owner/${ORG}"
+
+gcloud secrets add-iam-policy-binding clasp-credentials \
+  --role=roles/secretmanager.secretAccessor \
+  --member="principalSet://iam.googleapis.com/${POOL}/attribute.namespace_path/${GROUP}"
+```
+
+### 5. 開発者へのアクセス付与
+
+```bash
+gcloud secrets add-iam-policy-binding clasp-credentials \
+  --role=roles/secretmanager.secretAccessor \
+  --member="group:gas-developers@yourcompany.com"
+```
+
+### 6. Data Access 監査ログの有効化
+
+**デフォルト OFF・課金対象**です — アクセス単位の監査証跡が必要なら必須。
+[IAM → 監査ログ](https://console.cloud.google.com/iam-admin/audit)で
+**Secret Manager API** の **Data Read** を有効化するか、ポリシーで:
+
+```yaml
+# gcloud projects get-iam-policy $PROJECT_ID > policy.yaml に追記して set-iam-policy
+auditConfigs:
+  - service: secretmanager.googleapis.com
+    auditLogConfigs:
+      - logType: DATA_READ
+```
+
+以後、すべての `AccessSecretVersion` がフェデレーテッドプリンシパル付きで
+Cloud Logging に記録されます — `attribute.repository`(GitHub)/
+`project_path`(GitLab)を含むため、org 一括付与のままでもリポ単位で追跡
+できます。
+
+### 7. CI 変数の設定(org/group レベル、両プラットフォーム同名)
+
+| 変数 | 値 |
+| --- | --- |
+| `GCP_WIF_PROVIDER` | `projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/gas-fleet/providers/github`(GitHub)/ `…/providers/gitlab`(GitLab) |
+| `CLASPRC_SECRET` | `projects/<PROJECT_ID>/secrets/clasp-credentials` |
+
+- **GitHub**: Organization → Settings → Actions → Variables(secret ではなく
+  variable — 秘密情報ではないため)。
+- **GitLab**: Group → Settings → CI/CD → Variables。**unprotected** で設定して
+  ください: protected にすると `dev` パイプラインから見えず、dev デプロイが
+  気づかないうちに legacy モードに落ちます。
+
+## 開発者のアクセス
+
+```bash
+gcloud auth login          # 個人アカウント、マシンごとに1回
+./scripts/fetch-clasp-credentials.sh
+```
+
+- `~/.clasprc.json` は `$HOME` 配置なので、1回の取得で**マシン上の全リポ**を
+  カバーします。
+- スクリプトは冪等です: ファイルが存在すれば `--force` なしでは何もしません
+  (ローテーション後は `--force` で再取得)。
+- GCP プロジェクトは `--project` → `$CLASP_SECRET_PROJECT` →
+  `.clasp-dev.json` / `.clasp.json` の `projectId` の順で解決されます。
+- オフボーディング = Google グループから外すだけ。次のローテーション後は
+  手元のコピーも無効になります。
+
+## ローテーション
+
+旧方式では不可能でしたが、今後は定常運用です:
+
+1. デプロイ用アカウントで再度 `clasp login` →
+   `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`。
+   CI は `latest` 参照なので即時反映 — リポ側の作業はゼロ。
+2. 任意リポの dev デプロイで検証。
+3. `gcloud secrets versions disable <old>` → 猶予期間の後
+   `gcloud secrets versions destroy <old>`。
+4. 開発者は `./scripts/fetch-clasp-credentials.sh --force` で再取得。
+
+## 既存フリートの CLASPRC_JSON からの移行
+
+1. 上記の一度きりのセットアップ(CI 変数含む)を完了する。旧 `cd.yml` は未知の
+   変数を無視するため、先行設定は無害です。
+2. template-sync の PR/MR で新しい `cd.yml` + スクリプトが行き渡るのを待つ
+   (または手動 sync)。
+3. 数リポで WIF 経由のデプロイを確認 — Audit Logs にフェデレーテッド
+   プリンシパル付きの `AccessSecretVersion` が出ること。
+4. org secret / group variable の `CLASPRC_JSON` とパスワードマネージャーの
+   エントリを削除。`publish.yml` の `secrets: inherit` による露出も同時に
+   消滅します。
+
+## ハードニング: リポ単位付与(オプション)
+
+org/group 一括の `principalSet` の代わりに、リポ単位で付与できます:
+
+```bash
+# GitHub — 特定リポのみ
+--member="principalSet://iam.googleapis.com/${POOL}/attribute.repository/${ORG}/critical-repo"
+# GitLab — 特定プロジェクトのみ
+--member="principalSet://iam.googleapis.com/${POOL}/attribute.project_path/${GROUP}/critical-repo"
+```
+
+トレードオフ: 新リポごとに明示的な IAM 付与が必要になります。GitHub では
+`sub = repo:ORG/REPO:environment:production` で deployment environment に
+ピン留めもできますが、このテンプレは `workflow_run` トリガーでデプロイするため
+`ref` ベースの条件は不安定です — `repository` / `environment` クレームを
+使ってください。
+
+## スコープの限界(既知の制約)
+
+取り出した `.clasprc.json` は依然としてフリート内の**すべての** GAS プロジェクト
+を操作できるユーザー OAuth トークンです。この移行で改善されるのは配布・保管・
+失効・監査であり、トークン自体の爆発半径ではありません(Apps Script API の
+制約上、不可避です)。
+
+## トラブルシューティング
+
+| 症状 | 原因の見立て |
+| --- | --- |
+| STS 403 `unable to acquire impersonated credentials` / `The given credential is rejected by the attribute condition` | プロバイダの `--attribute-condition` 不一致(org/group 違い)、または JWT の `aud` が `--allowed-audiences` と不一致。JWT の `aud` = `$CI_SERVER_URL`(スキーム込み・末尾スラッシュ無し)。 |
+| STS 400 `Invalid value for "audience"` | STS リクエストの `audience` は `//iam.googleapis.com/projects/<NUM>/…/providers/<name>` — **`https:` プレフィックス無し**、プロジェクト**番号**を使う。 |
+| STS 400 `mapped attribute google.subject exceeds the 127 bytes limit` | JWT の `sub` が長すぎる(深くネストした GitLab group、長い GitHub repo/environment 名)。`google.subject` を短いクレームに再マップする(例: GitLab は `assertion.project_path`)— IAM は attribute にバインドしているため他は変更不要。 |
+| Secret Manager 403 `PERMISSION_DENIED`(CI) | `principalSet` バインディングの欠落・誤り。attribute 名(`repository_owner` / `namespace_path`)と値を確認。 |
+| `PERMISSION_DENIED`(開発者) | 開発者 Google グループに未所属、またはグループに `secretAccessor` が無い。 |
+| GitLab ジョブが script 前に `id_tokens` エラーで失敗 | GitLab < 16.1(`aud` の変数展開)または < 15.7(`id_tokens` 自体)。アップグレードするか、旧テンプレ + legacy モードを継続。 |
+| GitLab で `main` は WIF が通るが `dev` で失敗 | `GCP_WIF_PROVIDER` / `CLASPRC_SECRET` が **protected** 変数になっている。unprotected に変更。 |
+| エアギャップ GitLab | WIF は `sts.googleapis.com` + `secretmanager.googleapis.com` への egress が必要。legacy `CLASPRC_JSON` を継続使用。 |

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -1,0 +1,236 @@
+# Clasp Credentials via Secret Manager + Workload Identity Federation
+
+[日本語](secret-manager.ja.md)
+
+This is the single source of truth for the fleet's credential architecture. It
+replaces the legacy "org secret + password manager" distribution of
+`CLASPRC_JSON`.
+
+## Architecture
+
+**clasp authentication itself does not change.** clasp keeps using a
+`~/.clasprc.json` produced by `clasp login` (a user OAuth refresh token) —
+the Apps Script API does not support service accounts for script push/deploy,
+so this cannot be replaced with GCP-native auth. What changes is where that
+token is **stored** (Secret Manager) and how it is **delivered** (WIF for CI,
+personal gcloud for developers).
+
+Authentication is two-tier:
+
+1. **Getting `.clasprc.json` out of Secret Manager** — WIF (CI) or personal
+   gcloud (developers). This tier is where IAM gives you scoping, audit logs,
+   and rotation.
+2. **clasp deploying to GAS** — the fetched `.clasprc.json`, exactly as before.
+
+Everything is centralized — **zero per-repo setup**:
+
+| Resource | Count | Scope |
+| --- | --- | --- |
+| Secret `clasp-credentials` | 1 | Central GCP project; CI always reads `latest` |
+| WIF pool `gas-fleet` | 1 | Providers `github` + `gitlab` under it |
+| IAM binding | org/group-wide | `principalSet://…/attribute.repository_owner/<org>` (GitHub) / `attribute.namespace_path/<group>` (GitLab) |
+| CI variables `GCP_WIF_PROVIDER`, `CLASPRC_SECRET` | org/group-level | Inherited by every repo |
+
+Direct WIF is used — **no service-account impersonation**. Secret Manager
+accepts federated tokens directly, so the pool's `principalSet://` gets
+`roles/secretmanager.secretAccessor` with no intermediate service account, and
+audit logs record `attribute.repository` / `project_path` per access.
+
+### Dual-mode rule (both CI platforms)
+
+- `GCP_WIF_PROVIDER` set → Secret Manager path. A fetch failure **fails the
+  job** — there is no silent fallback to the legacy secret.
+- `GCP_WIF_PROVIDER` unset → legacy `CLASPRC_JSON` (kept for air-gapped GitLab).
+- Neither → explicit error.
+
+## One-Time Organization Setup
+
+All commands run against the central GCP project (the same one used for Cloud
+Logging / `clasp run`). Billing must be enabled.
+
+```bash
+PROJECT_ID=your-central-project        # alphanumeric project ID
+ORG=your-github-org                    # GitHub organization
+GROUP=your-gitlab-group                # GitLab top-level group
+GITLAB_URL=https://gitlab.example.com  # or https://gitlab.com
+gcloud config set project "$PROJECT_ID"
+PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+
+# 0. Enable APIs
+gcloud services enable secretmanager.googleapis.com sts.googleapis.com iam.googleapis.com
+```
+
+### 1. Create the secret
+
+With the dedicated deploy Google account (e.g. `gas-deploy@yourcompany.com`):
+
+```bash
+npx @google/clasp login            # writes ~/.clasprc.json
+gcloud secrets create clasp-credentials --replication-policy=automatic
+gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"
+```
+
+### 2. Create the WIF pool
+
+```bash
+gcloud iam workload-identity-pools create gas-fleet \
+  --location=global --display-name="GAS Fleet CI"
+```
+
+### 3a. GitHub provider
+
+The attribute condition is **required**: `token.actions.githubusercontent.com`
+is a multi-tenant issuer shared by every GitHub org.
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc github \
+  --location=global --workload-identity-pool=gas-fleet \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner == '${ORG}'"
+```
+
+### 3b. GitLab provider
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc gitlab \
+  --location=global --workload-identity-pool=gas-fleet \
+  --issuer-uri="${GITLAB_URL}" \
+  --allowed-audiences="${GITLAB_URL}" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.project_path=assertion.project_path,attribute.namespace_path=assertion.namespace_path" \
+  --attribute-condition="assertion.namespace_path == '${GROUP}' || assertion.namespace_path.startsWith('${GROUP}/')"
+```
+
+`--allowed-audiences` must equal the `aud` of the CI JWT, which the template
+sets to `$CI_SERVER_URL` (scheme included, no trailing slash).
+
+### 4. Grant CI access (org/group-wide)
+
+```bash
+POOL="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/gas-fleet"
+
+gcloud secrets add-iam-policy-binding clasp-credentials \
+  --role=roles/secretmanager.secretAccessor \
+  --member="principalSet://iam.googleapis.com/${POOL}/attribute.repository_owner/${ORG}"
+
+gcloud secrets add-iam-policy-binding clasp-credentials \
+  --role=roles/secretmanager.secretAccessor \
+  --member="principalSet://iam.googleapis.com/${POOL}/attribute.namespace_path/${GROUP}"
+```
+
+### 5. Grant developer access
+
+```bash
+gcloud secrets add-iam-policy-binding clasp-credentials \
+  --role=roles/secretmanager.secretAccessor \
+  --member="group:gas-developers@yourcompany.com"
+```
+
+### 6. Enable Data Access audit logs
+
+**Off by default and billed** — required if you want per-access audit trails.
+In [IAM → Audit Logs](https://console.cloud.google.com/iam-admin/audit), enable
+**Data Read** for **Secret Manager API**, or via policy:
+
+```yaml
+# gcloud projects get-iam-policy $PROJECT_ID > policy.yaml, add, then set-iam-policy
+auditConfigs:
+  - service: secretmanager.googleapis.com
+    auditLogConfigs:
+      - logType: DATA_READ
+```
+
+Afterwards every `AccessSecretVersion` appears in Cloud Logging with the
+federated principal — including `attribute.repository` (GitHub) /
+`project_path` (GitLab), so access is traceable per repo even with the
+org-wide grant.
+
+### 7. Set CI variables (org/group-level, same names on both platforms)
+
+| Variable | Value |
+| --- | --- |
+| `GCP_WIF_PROVIDER` | `projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/gas-fleet/providers/github` (GitHub) / `…/providers/gitlab` (GitLab) |
+| `CLASPRC_SECRET` | `projects/<PROJECT_ID>/secrets/clasp-credentials` |
+
+- **GitHub**: Organization → Settings → Actions → Variables (not secrets —
+  these values are not sensitive).
+- **GitLab**: Group → Settings → CI/CD → Variables. Set them **unprotected**:
+  protected variables are invisible on `dev` pipelines, which would silently
+  drop dev deploys into legacy mode.
+
+## Developer Access
+
+```bash
+gcloud auth login          # personal account, once per machine
+./scripts/fetch-clasp-credentials.sh
+```
+
+- `~/.clasprc.json` lives in `$HOME`, so one fetch covers **every repo on the
+  machine**.
+- The script is idempotent: if the file exists it does nothing without
+  `--force` (use `--force` after a rotation).
+- The GCP project is resolved from `--project` → `$CLASP_SECRET_PROJECT` →
+  `projectId` in `.clasp-dev.json` / `.clasp.json`.
+- Offboarding = remove the person from the Google group. After the next
+  rotation their local copy stops working too.
+
+## Rotation
+
+Impossible under the legacy model; now routine:
+
+1. `clasp login` again with the deploy account, then
+   `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`.
+   CI reads `latest`, so this takes effect immediately — zero repo-side work.
+2. Verify with any repo's dev deploy.
+3. `gcloud secrets versions disable <old>` → after a grace period
+   `gcloud secrets versions destroy <old>`.
+4. Developers re-fetch with `./scripts/fetch-clasp-credentials.sh --force`.
+
+## Migrating an Existing Fleet off CLASPRC_JSON
+
+1. Complete the one-time setup above, including the CI variables. Old `cd.yml`
+   revisions ignore unknown variables, so setting them early is harmless.
+2. Wait for template-sync PRs/MRs to deliver the new `cd.yml` + scripts (or
+   sync manually).
+3. Confirm a few repos deploy via WIF — check Audit Logs for
+   `AccessSecretVersion` with a federated principal.
+4. Delete the org secret / group variable `CLASPRC_JSON` and the password
+   manager entry. The `secrets: inherit` exposure in `publish.yml` disappears
+   with it.
+
+## Hardening: Per-Repo Grants (Optional)
+
+Instead of the org/group-wide `principalSet`, grant per repo:
+
+```bash
+# GitHub — one repo only
+--member="principalSet://iam.googleapis.com/${POOL}/attribute.repository/${ORG}/critical-repo"
+# GitLab — one project only
+--member="principalSet://iam.googleapis.com/${POOL}/attribute.project_path/${GROUP}/critical-repo"
+```
+
+Trade-off: every new repo needs an explicit IAM grant. You can also pin GitHub
+tokens to a deployment environment via
+`sub = repo:ORG/REPO:environment:production` — but note this template deploys
+from a `workflow_run` trigger, where `ref`-based conditions are unreliable;
+prefer `repository` / `environment` claims.
+
+## Scope Boundary (Known Limitation)
+
+The fetched `.clasprc.json` is still a user OAuth token that can operate on
+**every** GAS project in the fleet. This migration improves distribution,
+storage, revocation, and audit — not the blast radius of the token itself,
+which the Apps Script API makes unavoidable.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| STS 403 `unable to acquire impersonated credentials` / `The given credential is rejected by the attribute condition` | Provider `--attribute-condition` does not match (wrong org/group), or the JWT `aud` differs from `--allowed-audiences`. JWT `aud` = `$CI_SERVER_URL` with scheme, no trailing slash. |
+| STS 400 `Invalid value for "audience"` | STS request `audience` must be `//iam.googleapis.com/projects/<NUM>/…/providers/<name>` — **no `https:` prefix**, and it uses the project **number**. |
+| STS 400 `mapped attribute google.subject exceeds the 127 bytes limit` | The JWT `sub` is too long (deeply nested GitLab groups; long GitHub repo/environment names). Remap `google.subject` to a shorter claim, e.g. `assertion.project_path` (GitLab) — IAM here binds on attributes, not subject, so nothing else changes. |
+| Secret Manager 403 `PERMISSION_DENIED` (CI) | Missing/wrong `principalSet` binding. Verify the attribute name (`repository_owner` vs `namespace_path`) and value. |
+| `PERMISSION_DENIED` (developer) | Not in the developer Google group, or the group lacks `secretAccessor`. |
+| GitLab job fails before script with `id_tokens` error | GitLab < 16.1 (variable expansion in `aud`) or < 15.7 (`id_tokens` itself). Upgrade or stay on legacy mode with an older template revision. |
+| WIF works on `main` but not `dev` (GitLab) | `GCP_WIF_PROVIDER` / `CLASPRC_SECRET` set as **protected** variables. Make them unprotected. |
+| Air-gapped GitLab | WIF needs egress to `sts.googleapis.com` + `secretmanager.googleapis.com`. Keep using legacy `CLASPRC_JSON`. |

--- a/docs/setup-github.ja.md
+++ b/docs/setup-github.ja.md
@@ -10,9 +10,21 @@
 
 ## 初回：Organization の設定
 
-CI/CD 用の専用 Google アカウント（例: `gas-deploy@yourcompany.com`）を作成し、`clasp login` を実行。`~/.clasprc.json` の内容を **Organization Secret**（名前: `CLASPRC_JSON`）として追加します。
+clasp の共有認証情報を Google Cloud Secret Manager に格納し、CI は Workload Identity Federation でキーレス取得します — 詳細: [secret-manager.ja.md](secret-manager.ja.md)。概要:
 
-> このテンプレートから作成されるすべてのリポジトリがこの Secret を共有します。リポごとの認証設定は不要です。
+1. CI/CD 用の専用 Google アカウント（例: `gas-deploy@yourcompany.com`）を作成し、`clasp login` を実行。`~/.clasprc.json` を secret `clasp-credentials` に格納します。
+2. WIF プール `gas-fleet` に `github` プロバイダを作成し、org に attribute 制限（`assertion.repository_owner == '<org>'` — GitHub の issuer はマルチテナントのため必須）。
+3. `principalSet://…/attribute.repository_owner/<org>` に `roles/secretmanager.secretAccessor` を付与。
+4. **Organization variables** `GCP_WIF_PROVIDER` と `CLASPRC_SECRET` を設定。
+
+> このテンプレートから作成されるすべてのリポジトリが自動的に WIF で認証します。リポごとの認証設定は不要です。リポ単位のハードニングが必要な場合は、IAM を `attribute.repository/<org>/<repo>` にバインドするか、deployment environment にピン留め（`sub = repo:ORG/REPO:environment:ENV`）できます。注意: CD は `workflow_run` トリガーで動くため、`ref` ベースの OIDC 条件は不安定です — `repository` / `environment` クレームを使ってください。
+
+<details>
+<summary>Legacy フォールバック: <code>CLASPRC_JSON</code> Organization Secret</summary>
+
+`GCP_WIF_PROVIDER` 未設定時に自動的に使われます: `~/.clasprc.json` の内容を **Organization Secret**（名前: `CLASPRC_JSON`）として追加します。
+
+</details>
 
 ## プロジェクトごと：新しい GAS リポジトリの作成
 

--- a/docs/setup-github.md
+++ b/docs/setup-github.md
@@ -10,9 +10,21 @@
 
 ## One-Time: Organization Setup
 
-Create a dedicated Google account for CI/CD (e.g., `gas-deploy@yourcompany.com`), run `clasp login`, and add `~/.clasprc.json` as an **Organization Secret** named `CLASPRC_JSON`.
+Store the shared clasp credentials in Google Cloud Secret Manager and let CI fetch them keylessly via Workload Identity Federation — full guide: [secret-manager.md](secret-manager.md). In short:
 
-> Every repository created from this template will use this secret — no per-repo auth setup needed.
+1. Create a dedicated Google account for CI/CD (e.g., `gas-deploy@yourcompany.com`), run `clasp login`, and store `~/.clasprc.json` in the `clasp-credentials` secret.
+2. Create the WIF pool `gas-fleet` with a `github` provider, attribute-restricted to your org (`assertion.repository_owner == '<org>'` — required, the GitHub issuer is multi-tenant).
+3. Grant `roles/secretmanager.secretAccessor` to `principalSet://…/attribute.repository_owner/<org>`.
+4. Set **Organization variables** `GCP_WIF_PROVIDER` and `CLASPRC_SECRET`.
+
+> Every repository created from this template authenticates via WIF automatically — no per-repo auth setup needed. For per-repo hardening you can bind IAM to `attribute.repository/<org>/<repo>` instead, or pin tokens to a deployment environment (`sub = repo:ORG/REPO:environment:ENV`). Note: CD runs on a `workflow_run` trigger, where `ref`-based OIDC conditions are unreliable — prefer `repository` / `environment` claims.
+
+<details>
+<summary>Legacy fallback: <code>CLASPRC_JSON</code> Organization Secret</summary>
+
+Used automatically when `GCP_WIF_PROVIDER` is not set: add the contents of `~/.clasprc.json` as an **Organization Secret** named `CLASPRC_JSON`.
+
+</details>
 
 ## Per Project: Create a New Apps Script Repository
 

--- a/docs/setup-gitlab.ja.md
+++ b/docs/setup-gitlab.ja.md
@@ -10,11 +10,28 @@
 
 ## 初回: Group の設定
 
-### 1. CLASPRC_JSON の追加
+### 1. clasp 認証情報のセットアップ（Secret Manager + WIF）
 
-CI/CD 用の専用 Google アカウント（例: `gas-deploy@yourcompany.com`）を作成し、`clasp login` を実行。`~/.clasprc.json` の内容を **Group CI/CD Variable**（名前: `CLASPRC_JSON`、masked, protected）として追加します。
+clasp の共有認証情報を Google Cloud Secret Manager に格納し、CI は Workload Identity Federation でキーレス取得します — 詳細: [secret-manager.ja.md](secret-manager.ja.md)。概要:
 
-> Group 内でこのテンプレートから作成されるすべてのプロジェクトがこの変数を共有します。プロジェクトごとの認証設定は不要です。
+1. CI/CD 用の専用 Google アカウント（例: `gas-deploy@yourcompany.com`）を作成し、`clasp login` を実行。`~/.clasprc.json` を secret `clasp-credentials` に格納します。
+2. WIF プール `gas-fleet` に `gitlab` プロバイダを作成: `--issuer-uri` と `--allowed-audiences` の両方に GitLab のベース URL を設定（CI の JWT の `aud` は `$CI_SERVER_URL`）し、group に attribute 制限。
+3. `principalSet://…/attribute.namespace_path/<group>` に `roles/secretmanager.secretAccessor` を付与。
+4. **Group CI/CD Variables** `GCP_WIF_PROVIDER` と `CLASPRC_SECRET` を設定 — **unprotected** で（protected にすると `dev` パイプラインから見えず、dev デプロイが気づかないうちに legacy モードに落ちます）。
+
+要件:
+
+- **GitLab >= 16.1**（`id_tokens: aud` の変数展開）。
+- Runner から `sts.googleapis.com` と `secretmanager.googleapis.com` への egress — **エアギャップ環境は下記の legacy フォールバックを継続してください**。
+
+> Group 内でこのテンプレートから作成されるすべてのプロジェクトが自動的に WIF で認証します。プロジェクトごとの認証設定は不要です。
+
+<details>
+<summary>Legacy / エアギャップ向けフォールバック: <code>CLASPRC_JSON</code> Group Variable</summary>
+
+`GCP_WIF_PROVIDER` 未設定時に自動的に使われます: `~/.clasprc.json` の内容を **Group CI/CD Variable**（名前: `CLASPRC_JSON`、masked, protected）として追加します。
+
+</details>
 
 ### 2. Template Project の作成
 
@@ -130,7 +147,7 @@ pnpm run check    # lint + 型チェック + テスト
 | ジョブ          | 必要な外部通信先                                     |
 | --------------- | ---------------------------------------------------- |
 | `check`         | npm レジストリのみ（`pnpm install` 用）              |
-| `deploy_*`      | `script.google.com`（HTTPS）                         |
+| `deploy_*`      | `script.google.com`。WIF モードでは `sts.googleapis.com` + `secretmanager.googleapis.com` も必要 |
 | `template_sync` | Template Project（社内 GitLab、Group Variable 経由） |
 
 **Template Project:**

--- a/docs/setup-gitlab.md
+++ b/docs/setup-gitlab.md
@@ -10,11 +10,28 @@
 
 ## One-Time: Group Setup
 
-### 1. Add CLASPRC_JSON
+### 1. Set up clasp credentials (Secret Manager + WIF)
 
-Create a dedicated Google account for CI/CD (e.g., `gas-deploy@yourcompany.com`), run `clasp login`, and add the contents of `~/.clasprc.json` as a **Group CI/CD Variable** named `CLASPRC_JSON` (masked, protected).
+Store the shared clasp credentials in Google Cloud Secret Manager and let CI fetch them keylessly via Workload Identity Federation — full guide: [secret-manager.md](secret-manager.md). In short:
 
-> Every project created from this template within the group will use this variable — no per-project auth setup needed.
+1. Create a dedicated Google account for CI/CD (e.g., `gas-deploy@yourcompany.com`), run `clasp login`, and store `~/.clasprc.json` in the `clasp-credentials` secret.
+2. Create the WIF pool `gas-fleet` with a `gitlab` provider: `--issuer-uri` and `--allowed-audiences` both set to your GitLab base URL (the CI JWT's `aud` is `$CI_SERVER_URL`), attribute-restricted to your group.
+3. Grant `roles/secretmanager.secretAccessor` to `principalSet://…/attribute.namespace_path/<group>`.
+4. Set **Group CI/CD Variables** `GCP_WIF_PROVIDER` and `CLASPRC_SECRET` — **unprotected** (protected variables are invisible on `dev` pipelines, silently dropping dev deploys into legacy mode).
+
+Requirements:
+
+- **GitLab >= 16.1** (variable expansion in `id_tokens: aud`).
+- Runner egress to `sts.googleapis.com` and `secretmanager.googleapis.com` — **air-gapped instances must stay on the legacy fallback below**.
+
+> Every project created from this template within the group authenticates via WIF automatically — no per-project auth setup needed.
+
+<details>
+<summary>Legacy / air-gapped fallback: <code>CLASPRC_JSON</code> Group Variable</summary>
+
+Used automatically when `GCP_WIF_PROVIDER` is not set: add the contents of `~/.clasprc.json` as a **Group CI/CD Variable** named `CLASPRC_JSON` (masked, protected).
+
+</details>
 
 ### 2. Create the Template Project
 
@@ -130,7 +147,7 @@ Push to `dev` triggers dev deployment, push to `main` triggers production deploy
 | Job             | Outbound network access required                       |
 | --------------- | ------------------------------------------------------ |
 | `check`         | npm registry only (for `pnpm install`)                 |
-| `deploy_*`      | `script.google.com` (HTTPS)                            |
+| `deploy_*`      | `script.google.com`; WIF mode adds `sts.googleapis.com` + `secretmanager.googleapis.com` |
 | `template_sync` | Template Project (internal GitLab, via Group Variable) |
 
 **Template Project:**

--- a/scripts/fetch-clasp-credentials.sh
+++ b/scripts/fetch-clasp-credentials.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apps Script Fleet — fetch shared clasp credentials from Secret Manager.
+#
+# Writes the fleet's shared ~/.clasprc.json (clasp OAuth token) from Google
+# Cloud Secret Manager using your personal gcloud credentials. Replaces the
+# legacy "copy from the org password manager" flow.
+#
+# ~/.clasprc.json lives in $HOME, so one fetch covers every repo on this
+# machine. Access is governed by IAM (roles/secretmanager.secretAccessor).
+#
+# Usage:
+#   ./scripts/fetch-clasp-credentials.sh [--project <PROJECT_ID>] [--secret <NAME>] [--force]
+#
+# Project resolution order:
+#   --project → $CLASP_SECRET_PROJECT → projectId in .clasp-dev.json / .clasp.json
+
+SECRET_NAME="clasp-credentials"
+PROJECT="${CLASP_SECRET_PROJECT:-}"
+FORCE=0
+CLASPRC="$HOME/.clasprc.json"
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed."
+}
+
+json_value() {
+  node -e "process.stdout.write(String(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))[process.argv[2]] ?? ''))" "$1" "$2"
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --project)
+      PROJECT="$2"
+      shift 2
+      ;;
+    --secret)
+      SECRET_NAME="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    *)
+      die "Unknown option: $1 (usage: $0 [--project <PROJECT_ID>] [--secret <NAME>] [--force])"
+      ;;
+  esac
+done
+
+# Idempotent: an existing ~/.clasprc.json covers every repo on this machine.
+if [[ -f "$CLASPRC" && "$FORCE" -ne 1 ]]; then
+  echo "$CLASPRC already exists — nothing to do (it is shared across all repos on this machine)."
+  echo "Use --force to re-fetch, e.g. after a credential rotation."
+  exit 0
+fi
+
+require_cmd gcloud
+require_cmd node
+
+active_account=$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null || true)
+[[ -n "$active_account" ]] || die "No active gcloud account. Run: gcloud auth login"
+
+# Resolve the GCP project holding the secret.
+if [[ -z "$PROJECT" ]]; then
+  for f in .clasp-dev.json .clasp.json; do
+    if [[ -f "$f" ]]; then
+      PROJECT=$(json_value "$f" projectId)
+      [[ -n "$PROJECT" ]] && break
+    fi
+  done
+fi
+[[ -n "$PROJECT" ]] || die "Cannot resolve the GCP project. Pass --project <PROJECT_ID>, set \$CLASP_SECRET_PROJECT, or run from a repo whose .clasp-dev.json has a projectId."
+
+echo "Fetching secret '${SECRET_NAME}' from project '${PROJECT}' as ${active_account}..."
+umask 077
+tmp=$(mktemp "${CLASPRC}.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+
+if ! gcloud secrets versions access latest --secret="$SECRET_NAME" --project="$PROJECT" > "$tmp"; then
+  die "Failed to access the secret. If you see PERMISSION_DENIED, ask an admin to add you to the developer group that has roles/secretmanager.secretAccessor on '${SECRET_NAME}'."
+fi
+
+node -e '
+  const fs = require("fs");
+  const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  if (typeof data !== "object" || data === null || Object.keys(data).length === 0) {
+    throw new Error("empty JSON object");
+  }
+' "$tmp" || die "Fetched payload is not valid clasp credentials JSON — not installing it."
+
+mv "$tmp" "$CLASPRC"
+trap - EXIT
+echo "Wrote $CLASPRC (mode 600). All repos on this machine now share it."

--- a/scripts/gcp-get-secret.sh
+++ b/scripts/gcp-get-secret.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apps Script Fleet — GitLab CI: fetch a secret from Google Cloud Secret Manager
+# via Workload Identity Federation (keyless, no service-account impersonation).
+#
+# Usage:
+#   ./scripts/gcp-get-secret.sh "projects/<PROJECT_ID>/secrets/<NAME>" > payload
+#
+# Requires (set by .gitlab/cd.yml):
+#   GCP_OIDC_TOKEN    GitLab CI id_token (JWT). Its `aud` must match the WIF
+#                     provider's --allowed-audiences ($CI_SERVER_URL).
+#   GCP_WIF_PROVIDER  projects/<NUM>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
+#
+# Designed for the node:24 image: curl + node only (no gcloud, no jq).
+# SECURITY: never enable `set -x` in this script — the exchanged access token
+# and the secret payload must not appear in the job log. The payload goes to
+# stdout only; everything else goes to stderr.
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+SECRET_RESOURCE="${1:-}"
+[[ -n "$SECRET_RESOURCE" ]] || die "usage: $0 projects/<PROJECT_ID>/secrets/<NAME>"
+[[ -n "${GCP_OIDC_TOKEN:-}" ]] || die "GCP_OIDC_TOKEN is not set. Add 'id_tokens: GCP_OIDC_TOKEN: aud: \$CI_SERVER_URL' to the job (GitLab >= 16.1)."
+[[ -n "${GCP_WIF_PROVIDER:-}" ]] || die "GCP_WIF_PROVIDER is not set."
+
+# 1. Exchange the GitLab OIDC token for a federated access token via STS.
+#    Note the audience format: //iam.googleapis.com/<provider> (no https:).
+#    JSON is assembled by node from env so the JWT never hits a command line.
+# shellcheck disable=SC2016  # ${} below is a JS template literal, not shell
+sts_request=$(node -e '
+  process.stdout.write(JSON.stringify({
+    audience: `//iam.googleapis.com/${process.env.GCP_WIF_PROVIDER}`,
+    grantType: "urn:ietf:params:oauth:grant-type:token-exchange",
+    requestedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+    scope: "https://www.googleapis.com/auth/cloud-platform",
+    subjectToken: process.env.GCP_OIDC_TOKEN,
+    subjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+  }));
+')
+
+if ! sts_response=$(curl -sS --fail-with-body -X POST "https://sts.googleapis.com/v1/token" \
+  -H "Content-Type: application/json" --data-binary "$sts_request"); then
+  # STS error bodies contain no secrets — safe and useful to show.
+  echo "$sts_response" >&2
+  die "STS token exchange failed. Check the WIF provider's attribute condition and allowed audiences (JWT aud = \$CI_SERVER_URL)."
+fi
+
+access_token=$(printf '%s' "$sts_response" | node -e '
+  let d = "";
+  process.stdin.on("data", (c) => (d += c)).on("end", () => {
+    const t = JSON.parse(d).access_token;
+    if (!t) { console.error("No access_token in STS response."); process.exit(1); }
+    process.stdout.write(t);
+  });
+')
+
+# 2. Access the secret payload. The Authorization header is passed via a curl
+#    config on stdin so the token never appears in argv.
+if ! secret_response=$(curl -sS --fail-with-body --config - <<CURLCFG
+url = "https://secretmanager.googleapis.com/v1/${SECRET_RESOURCE}/versions/latest:access"
+header = "Authorization: Bearer ${access_token}"
+CURLCFG
+); then
+  echo "$secret_response" >&2
+  die "Secret Manager access failed for ${SECRET_RESOURCE}. Check the principalSet IAM binding (roles/secretmanager.secretAccessor)."
+fi
+
+# 3. Decode payload.data (base64) and emit to stdout.
+printf '%s' "$secret_response" | node -e '
+  let d = "";
+  process.stdin.on("data", (c) => (d += c)).on("end", () => {
+    const p = JSON.parse(d).payload;
+    if (!p || !p.data) { console.error("No payload in Secret Manager response."); process.exit(1); }
+    process.stdout.write(Buffer.from(p.data, "base64").toString("utf8"));
+  });
+'

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # Apps Script Fleet — Project Init
 #
 # Prerequisites:
-#   - ~/.clasprc.json exists (shared via org password manager)
+#   - ~/.clasprc.json exists — run ./scripts/fetch-clasp-credentials.sh
+#     (Secret Manager), or copy from the org password manager (legacy)
 #   - GitHub: gh CLI authenticated | GitLab: glab CLI authenticated
 #   - Node.js + pnpm installed
 #
@@ -291,7 +292,7 @@ echo "=== Apps Script Fleet — Project Init ==="
 echo ""
 
 # Checks
-[[ -f "$HOME/.clasprc.json" ]] || die "$HOME/.clasprc.json not found. Copy it from your organization's password manager."
+[[ -f "$HOME/.clasprc.json" ]] || die "$HOME/.clasprc.json not found. Run ./scripts/fetch-clasp-credentials.sh (Secret Manager), or copy it from your organization's password manager (legacy)."
 require_cmd pnpm
 require_cmd node
 validate_type "$GAS_TYPE"


### PR DESCRIPTION
Closes #41

## Summary

clasp 認証情報(`~/.clasprc.json`)の保管を Google Cloud Secret Manager に移し、配送を WIF(CI・キーレス)/ 個人 gcloud + IAM(開発者)に置き換える。**clasp 認証そのものは不変**(Apps Script API がサービスアカウント非対応のため)。旧 `CLASPRC_JSON` はエアギャップ GitLab 向けの明示フォールバックとして存続。

- **秘密は1つ・org/group 単位 IAM・org/group 変数** → 新リポのセットアップ作業ゼロのまま、旧方式に無かったローテーション・失効・監査ログ(`attribute.repository` / `project_path` 単位)を獲得
- **直接 WIF(SA 偽装なし)**: WIF プール `gas-fleet` の `principalSet://` に `secretmanager.secretAccessor` を直付与
- **デュアルモード(両 CI 共通)**: `GCP_WIF_PROVIDER` 設定済み → Secret Manager(失敗はジョブ失敗、サイレントフォールバック無し)/ 未設定 → legacy `CLASPRC_JSON` / 両方無し → 明示エラー
- **インジェクション修正を同梱**: `cd.yml` の `echo '${{ secrets.* }}'` を env 経由の `printf` に置換(`CLASP_JSON` / `SCRIPT_PROPERTIES` の step-if `secrets` コンテキスト問題も修正)

## Changes

| ファイル | 内容 |
| --- | --- |
| `.github/workflows/cd.yml` | `permissions`(contents:read + id-token:write)、SHA 固定の `google-github-actions/auth@v3` + `get-secretmanager-secrets@v3`(`vars.GCP_WIF_PROVIDER` でゲート)、env 経由 printf のデュアルモード credential 書き込み |
| `.gitlab/cd.yml` / `.gitlab/post-deploy.yml.example` | `id_tokens: aud: $CI_SERVER_URL`(GitLab >= 16.1)、デュアルモード分岐(umask 077) |
| `scripts/gcp-get-secret.sh` (new) | GitLab CI 用: OIDC JWT → STS 交換 → Secret Manager REST `:access`。curl + node のみ、トークン/ペイロードはログ非出力 |
| `scripts/fetch-clasp-credentials.sh` (new) | 開発者用: gcloud 認証で取得、冪等($HOME 全リポ共有)、JSON 検証、mode 600 |
| `scripts/init.sh` | 前提条件メッセージを Secret Manager ファーストに更新 |
| `docs/secret-manager(.ja).md` (new) | single source of truth: org セットアップ、ローテーション、移行、リポ単位ハードニング、トラブルシューティング |
| `README(.ja).md` / `docs/setup-*(.ja).md` | WIF ファーストに書き換え、legacy は `<details>` へ。GitLab 16.1 床・egress 要件・unprotected 変数の注意を明記 |
| `.templatesyncignore` | 新規4ファイルをホワイトリストに追加(同一コミット) |

## Test plan

- [x] `pnpm run check` パス(lint / typecheck / test 100%)
- [x] `shellcheck` パス(新規スクリプト2本 + init.sh)
- [x] `actionlint .github/workflows/cd.yml` パス(既存の step-if `secrets` コンテキスト違反も解消)
- [x] `.gitlab/cd.yml` / `post-deploy.yml.example` YAML パース確認
- [x] `templatesyncignore_check` ロジックをローカル再現しパス
- [x] スクリプト負パス検証(隔離 $HOME): 引数無し / OIDC トークン無し / 不明オプション → 明示エラー、既存 `~/.clasprc.json` → 冪等スキップ(exit 0)
- [x] action の SHA は tag をデリファレンスして commit 実体を確認(`auth@v3.0.0` = `7c6bc77`、`get-secretmanager-secrets@v3.0.0` = `bc9c54b`)
- [x] 実 GCP 環境での E2E(org セットアップ後): WIF デプロイ成功 + Audit Logs、IAM 剥奪で大声で失敗、org 外リポからの STS 交換 403 — `docs/secret-manager.md` の手順に従い実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)
