### PR TITLE
docs: fold field-tested learnings into Secret Manager guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -80,7 +80,7 @@ Apps Script Fleet は各 GAS 機能を独立したリポジトリとして扱い
 
 詳細な手順: **[docs/secret-manager.ja.md](docs/secret-manager.ja.md)**。概要:
 
-1. **認証情報の格納**: デプロイ用アカウントで `clasp login` → `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`
+1. **認証情報の格納**: デプロイ用アカウントの [Apps Script API を有効化](https://script.google.com/home/usersettings)し、そのアカウントで `clasp login` → `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`
 2. **WIF プール `gas-fleet` を作成**し、`github` / `gitlab` プロバイダを org/group に attribute 制限
 3. **`roles/secretmanager.secretAccessor` を付与**: CI の `principalSet://` と開発者 Google グループへ
 4. **org/group の CI 変数** `GCP_WIF_PROVIDER` + `CLASPRC_SECRET` を設定（両プラットフォーム同名）

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Before your team can use Apps Script Fleet, an org admin stores the shared clasp
 
 Full step-by-step guide: **[docs/secret-manager.md](docs/secret-manager.md)**. In outline:
 
-1. **Store credentials**: `clasp login` with the deploy account → `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`
+1. **Store credentials**: enable the [Apps Script API](https://script.google.com/home/usersettings) for the deploy account, `clasp login` with it → `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`
 2. **Create WIF pool `gas-fleet`** with `github` / `gitlab` providers, attribute-restricted to your org/group
 3. **Grant `roles/secretmanager.secretAccessor`** to the CI `principalSet://` and to the developer Google group
 4. **Set org/group CI variables** `GCP_WIF_PROVIDER` + `CLASPRC_SECRET` (same names on both platforms)

--- a/docs/secret-manager.ja.md
+++ b/docs/secret-manager.ja.md
@@ -67,6 +67,12 @@ gcloud services enable secretmanager.googleapis.com sts.googleapis.com \
 
 デプロイ専用 Google アカウント(例: `gas-deploy@yourcompany.com`)で:
 
+まずそのアカウントの **Apps Script API** を
+[script.google.com/home/usersettings](https://script.google.com/home/usersettings)
+で有効化します — アカウント単位の設定で、無効のままだと `clasp create`/`push`
+が `User has not enabled the Apps Script API` で失敗します(反映まで数分
+かかる場合あり)。
+
 ```bash
 npx @google/clasp login            # ~/.clasprc.json を生成
 

--- a/docs/secret-manager.ja.md
+++ b/docs/secret-manager.ja.md
@@ -57,8 +57,10 @@ GITLAB_URL=https://gitlab.example.com  # または https://gitlab.com
 gcloud config set project "$PROJECT_ID"
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
 
-# 0. API の有効化
-gcloud services enable secretmanager.googleapis.com sts.googleapis.com iam.googleapis.com
+# 0. API の有効化(cloudresourcemanager は GitHub Action がプロジェクト解決に
+#    使用 — 無いと secret 取得が実行時に失敗する)
+gcloud services enable secretmanager.googleapis.com sts.googleapis.com \
+  iam.googleapis.com cloudresourcemanager.googleapis.com
 ```
 
 ### 1. secret の作成
@@ -70,6 +72,16 @@ npx @google/clasp login            # ~/.clasprc.json を生成
 gcloud secrets create clasp-credentials --replication-policy=automatic
 gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"
 ```
+
+> 組織ポリシー `constraints/gcp.resourceLocations` が有効な組織では、
+> `automatic`(global)レプリケーションは `FAILED_PRECONDITION` で拒否され
+> ます。許可リージョンにレプリカを固定してください — リソース名・アクセス
+> パス・IAM は変わりません:
+>
+> ```bash
+> gcloud secrets create clasp-credentials \
+>   --replication-policy=user-managed --locations=asia-northeast1
+> ```
 
 ### 2. WIF プールの作成
 
@@ -119,6 +131,10 @@ gcloud secrets add-iam-policy-binding clasp-credentials \
   --member="principalSet://iam.googleapis.com/${POOL}/attribute.namespace_path/${GROUP}"
 ```
 
+> `principalSet://` メンバーへの IAM 変更は反映まで数分かかることがあります。
+> この直後の初回 CI 実行での `PERMISSION_DENIED` は、多くの場合「2〜5分待って
+> リトライ」で解決します — 設定ミスと決めつけないでください。
+
 ### 5. 開発者へのアクセス付与
 
 ```bash
@@ -154,7 +170,8 @@ Cloud Logging に記録されます — `attribute.repository`(GitHub)/
 | `CLASPRC_SECRET` | `projects/<PROJECT_ID>/secrets/clasp-credentials` |
 
 - **GitHub**: Organization → Settings → Actions → Variables(secret ではなく
-  variable — 秘密情報ではないため)。
+  variable — 秘密情報ではないため)。個人アカウント(org なし)の場合は
+  リポジトリ変数として設定します。
 - **GitLab**: Group → Settings → CI/CD → Variables。**unprotected** で設定して
   ください: protected にすると `dev` パイプラインから見えず、dev デプロイが
   気づかないうちに legacy モードに落ちます。
@@ -230,7 +247,10 @@ org/group 一括の `principalSet` の代わりに、リポ単位で付与でき
 | STS 403 `unable to acquire impersonated credentials` / `The given credential is rejected by the attribute condition` | プロバイダの `--attribute-condition` 不一致(org/group 違い)、または JWT の `aud` が `--allowed-audiences` と不一致。JWT の `aud` = `$CI_SERVER_URL`(スキーム込み・末尾スラッシュ無し)。 |
 | STS 400 `Invalid value for "audience"` | STS リクエストの `audience` は `//iam.googleapis.com/projects/<NUM>/…/providers/<name>` — **`https:` プレフィックス無し**、プロジェクト**番号**を使う。 |
 | STS 400 `mapped attribute google.subject exceeds the 127 bytes limit` | JWT の `sub` が長すぎる(深くネストした GitLab group、長い GitHub repo/environment 名)。`google.subject` を短いクレームに再マップする(例: GitLab は `assertion.project_path`)— IAM は attribute にバインドしているため他は変更不要。 |
-| Secret Manager 403 `PERMISSION_DENIED`(CI) | `principalSet` バインディングの欠落・誤り。attribute 名(`repository_owner` / `namespace_path`)と値を確認。 |
+| `secrets create` が `FAILED_PRECONDITION`(`constraints/gcp.resourceLocations`) | 組織ポリシーが global レプリケーションを禁止。`--replication-policy=user-managed --locations=<許可リージョン>` で作成(許可リージョンは `gcloud org-policies describe gcp.resourceLocations --project=… --effective` で確認)。 |
+| CI の secret 取得時に `cloud Resource Manager API has not been used in project …` | 中央プロジェクトで `cloudresourcemanager.googleapis.com` を有効化 — `get-secretmanager-secrets` がプロジェクト解決に使用。 |
+| Secret Manager 403 `PERMISSION_DENIED`(CI)— セットアップ直後 | `principalSet` の IAM バインディングは反映に数分かかる。2〜5分待ってリトライしてから疑うこと。 |
+| Secret Manager 403 `PERMISSION_DENIED`(CI)— 継続する場合 | `principalSet` バインディングの欠落・誤り。attribute 名(`repository_owner` / `namespace_path`)と値を確認。 |
 | `PERMISSION_DENIED`(開発者) | 開発者 Google グループに未所属、またはグループに `secretAccessor` が無い。 |
 | GitLab ジョブが script 前に `id_tokens` エラーで失敗 | GitLab < 16.1(`aud` の変数展開)または < 15.7(`id_tokens` 自体)。アップグレードするか、旧テンプレ + legacy モードを継続。 |
 | GitLab で `main` は WIF が通るが `dev` で失敗 | `GCP_WIF_PROVIDER` / `CLASPRC_SECRET` が **protected** 変数になっている。unprotected に変更。 |

--- a/docs/secret-manager.ja.md
+++ b/docs/secret-manager.ja.md
@@ -170,14 +170,23 @@ gcloud secrets add-iam-policy-binding clasp-credentials \
 
 **デフォルト OFF・課金対象**です — アクセス単位の監査証跡が必要なら必須。
 [IAM → 監査ログ](https://console.cloud.google.com/iam-admin/audit)で
-**Secret Manager API** の **Data Read** を有効化するか、ポリシーで:
+**Secret Manager API** の **Data Read** を有効化するか、スクリプトで
+(既存の audit 設定を壊さずに `DATA_READ` をマージします):
 
-```yaml
-# gcloud projects get-iam-policy $PROJECT_ID > policy.yaml に追記して set-iam-policy
-auditConfigs:
-  - service: secretmanager.googleapis.com
-    auditLogConfigs:
-      - logType: DATA_READ
+```bash
+gcloud projects get-iam-policy "$PROJECT_ID" --format=json > /tmp/policy.json
+python3 - <<'EOF'
+import json
+p = json.load(open("/tmp/policy.json"))
+a = p.setdefault("auditConfigs", [])
+e = next((x for x in a if x.get("service") == "secretmanager.googleapis.com"), None)
+if e is None:
+    a.append({"service": "secretmanager.googleapis.com", "auditLogConfigs": [{"logType": "DATA_READ"}]})
+elif not any(c.get("logType") == "DATA_READ" for c in e.setdefault("auditLogConfigs", [])):
+    e["auditLogConfigs"].append({"logType": "DATA_READ"})
+json.dump(p, open("/tmp/policy.json", "w"), indent=2)
+EOF
+gcloud projects set-iam-policy "$PROJECT_ID" /tmp/policy.json
 ```
 
 以後、すべての `AccessSecretVersion` がフェデレーテッドプリンシパル付きで
@@ -193,8 +202,17 @@ Cloud Logging に記録されます — `attribute.repository`(GitHub)/
 | `CLASPRC_SECRET` | `projects/<PROJECT_ID>/secrets/clasp-credentials` |
 
 - **GitHub**: Organization → Settings → Actions → Variables(secret ではなく
-  variable — 秘密情報ではないため)。個人アカウント(org なし)の場合は
-  リポジトリ変数として設定します。
+  variable — 秘密情報ではないため)。CLI の場合は `admin:org` スコープが必要
+  です(403 が出たら先に `gh auth refresh -h github.com -s admin:org`):
+
+  ```bash
+  gh variable set GCP_WIF_PROVIDER --org "$ORG" --visibility all \
+    --body "projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/gas-fleet/providers/github"
+  gh variable set CLASPRC_SECRET --org "$ORG" --visibility all \
+    --body "projects/${PROJECT_ID}/secrets/clasp-credentials"
+  ```
+
+  個人アカウント(org なし)の場合はリポジトリ変数として設定します。
 - **GitLab**: Group → Settings → CI/CD → Variables。**unprotected** で設定して
   ください: protected にすると `dev` パイプラインから見えず、dev デプロイが
   気づかないうちに legacy モードに落ちます。

--- a/docs/secret-manager.ja.md
+++ b/docs/secret-manager.ja.md
@@ -212,6 +212,10 @@ Cloud Logging に記録されます — `attribute.repository`(GitHub)/
     --body "projects/${PROJECT_ID}/secrets/clasp-credentials"
   ```
 
+  環境変数 `GH_TOKEN` が設定されているとそちらが優先され、`gh auth refresh`
+  も新スコープも効きません — その場合はコマンドに `env -u GH_TOKEN` を
+  前置してください。
+
   個人アカウント(org なし)の場合はリポジトリ変数として設定します。
 - **GitLab**: Group → Settings → CI/CD → Variables。**unprotected** で設定して
   ください: protected にすると `dev` パイプラインから見えず、dev デプロイが

--- a/docs/secret-manager.ja.md
+++ b/docs/secret-manager.ja.md
@@ -119,21 +119,33 @@ gcloud iam workload-identity-pools providers create-oidc gitlab \
 
 ### 4. CI へのアクセス付与(org/group 単位)
 
+secret リソースではなく、**プロジェクトレベル**で付与します:
+
 ```bash
 POOL="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/gas-fleet"
 
-gcloud secrets add-iam-policy-binding clasp-credentials \
-  --role=roles/secretmanager.secretAccessor \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --role=roles/secretmanager.secretAccessor --condition=None \
   --member="principalSet://iam.googleapis.com/${POOL}/attribute.repository_owner/${ORG}"
 
-gcloud secrets add-iam-policy-binding clasp-credentials \
-  --role=roles/secretmanager.secretAccessor \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --role=roles/secretmanager.secretAccessor --condition=None \
   --member="principalSet://iam.googleapis.com/${POOL}/attribute.namespace_path/${GROUP}"
 ```
 
-> `principalSet://` メンバーへの IAM 変更は反映まで数分かかることがあります。
-> この直後の初回 CI 実行での `PERMISSION_DENIED` は、多くの場合「2〜5分待って
-> リトライ」で解決します — 設定ミスと決めつけないでください。
+> **フィールドノート — なぜプロジェクトレベルか:** `principalSet://` への
+> `secretAccessor` を secret 単体に付与(`gcloud secrets
+> add-iam-policy-binding`)した場合、バインディングから30分以上経過しても
+> フェデレーテッド CI プリンシパルに対して `PERMISSION_DENIED` が返り続ける
+> 事象を実環境で確認しました。同じメンバーをプロジェクトレベルで付与すると
+> 数分で有効になります。中央プロジェクトはフリートの secret 専用なので、
+> プロジェクトレベル付与でも実質的なアクセス範囲は広がりません — ただし
+> 将来このプロジェクトに無関係な secret を追加する場合は、この判断を再検討
+> してください。
+>
+> また、`principalSet://` の IAM 変更は反映まで数分かかることがあります。
+> 直後の初回 CI 実行での `PERMISSION_DENIED` は「待ってリトライ」で解決する
+> ことが多いです。
 
 ### 5. 開発者へのアクセス付与
 
@@ -218,7 +230,8 @@ gcloud auth login          # 個人アカウント、マシンごとに1回
 
 ## ハードニング: リポ単位付与(オプション)
 
-org/group 一括の `principalSet` の代わりに、リポ単位で付与できます:
+org/group 一括の `principalSet` の代わりに、リポ単位で付与できます(§4 の
+フィールドノートのとおり、こちらもプロジェクトレベルで):
 
 ```bash
 # GitHub — 特定リポのみ
@@ -250,7 +263,7 @@ org/group 一括の `principalSet` の代わりに、リポ単位で付与でき
 | `secrets create` が `FAILED_PRECONDITION`(`constraints/gcp.resourceLocations`) | 組織ポリシーが global レプリケーションを禁止。`--replication-policy=user-managed --locations=<許可リージョン>` で作成(許可リージョンは `gcloud org-policies describe gcp.resourceLocations --project=… --effective` で確認)。 |
 | CI の secret 取得時に `cloud Resource Manager API has not been used in project …` | 中央プロジェクトで `cloudresourcemanager.googleapis.com` を有効化 — `get-secretmanager-secrets` がプロジェクト解決に使用。 |
 | Secret Manager 403 `PERMISSION_DENIED`(CI)— セットアップ直後 | `principalSet` の IAM バインディングは反映に数分かかる。2〜5分待ってリトライしてから疑うこと。 |
-| Secret Manager 403 `PERMISSION_DENIED`(CI)— 継続する場合 | `principalSet` バインディングの欠落・誤り。attribute 名(`repository_owner` / `namespace_path`)と値を確認。 |
+| Secret Manager 403 `PERMISSION_DENIED`(CI)— 継続する場合 | `principalSet` バインディングの欠落・誤り(attribute 名 `repository_owner` / `namespace_path` と値を確認)、**または secret 単体への付与になっている — プロジェクトレベルに移す**(実環境で検証済み、§4 参照)。 |
 | `PERMISSION_DENIED`(開発者) | 開発者 Google グループに未所属、またはグループに `secretAccessor` が無い。 |
 | GitLab ジョブが script 前に `id_tokens` エラーで失敗 | GitLab < 16.1(`aud` の変数展開)または < 15.7(`id_tokens` 自体)。アップグレードするか、旧テンプレ + legacy モードを継続。 |
 | GitLab で `main` は WIF が通るが `dev` で失敗 | `GCP_WIF_PROVIDER` / `CLASPRC_SECRET` が **protected** 変数になっている。unprotected に変更。 |

--- a/docs/secret-manager.ja.md
+++ b/docs/secret-manager.ja.md
@@ -69,6 +69,11 @@ gcloud services enable secretmanager.googleapis.com sts.googleapis.com \
 
 ```bash
 npx @google/clasp login            # ~/.clasprc.json を生成
+
+# 格納前にアカウントを検証する — このファイルがフリート全体のデプロイ主体を
+# 決める。過去の作業で残った古い ~/.clasprc.json を誤って格納しやすい:
+node -e 'const rc=JSON.parse(require("fs").readFileSync(process.env.HOME+"/.clasprc.json","utf8"));const t=rc.tokens?.default??{client_id:rc.oauth2ClientSettings?.clientId,client_secret:rc.oauth2ClientSettings?.clientSecret,refresh_token:rc.token?.refresh_token};fetch("https://oauth2.googleapis.com/token",{method:"POST",headers:{"Content-Type":"application/x-www-form-urlencoded"},body:new URLSearchParams({client_id:t.client_id,client_secret:t.client_secret,refresh_token:t.refresh_token,grant_type:"refresh_token"})}).then(r=>r.json()).then(x=>fetch("https://www.googleapis.com/drive/v3/about?fields=user(emailAddress)",{headers:{Authorization:"Bearer "+x.access_token}})).then(r=>r.json()).then(w=>console.log("deploy account:",w.user?.emailAddress))'
+
 gcloud secrets create clasp-credentials --replication-policy=automatic
 gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"
 ```
@@ -211,6 +216,10 @@ gcloud auth login          # 個人アカウント、マシンごとに1回
 1. デプロイ用アカウントで再度 `clasp login` →
    `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`。
    CI は `latest` 参照なので即時反映 — リポ側の作業はゼロ。
+   実行前に §1 のアカウント検証ワンライナーを必ず実行すること — この同じ
+   フローは**デプロイアカウントの交換**にも使われるため、マシンに残った
+   別アカウントの `~/.clasprc.json` を格納するとフリートのデプロイ主体が
+   静かに変わってしまいます。
 2. 任意リポの dev デプロイで検証。
 3. `gcloud secrets versions disable <old>` → 猶予期間の後
    `gcloud secrets versions destroy <old>`。
@@ -265,6 +274,7 @@ org/group 一括の `principalSet` の代わりに、リポ単位で付与でき
 | Secret Manager 403 `PERMISSION_DENIED`(CI)— セットアップ直後 | `principalSet` の IAM バインディングは反映に数分かかる。2〜5分待ってリトライしてから疑うこと。 |
 | Secret Manager 403 `PERMISSION_DENIED`(CI)— 継続する場合 | `principalSet` バインディングの欠落・誤り(attribute 名 `repository_owner` / `namespace_path` と値を確認)、**または secret 単体への付与になっている — プロジェクトレベルに移す**(実環境で検証済み、§4 参照)。 |
 | `PERMISSION_DENIED`(開発者) | 開発者 Google グループに未所属、またはグループに `secretAccessor` が無い。 |
+| GAS スクリプトの所有者が意図しないアカウントになっている | マシンに残っていた古い `~/.clasprc.json` から secret を格納したのが原因。スクリプトの所有権はドメイン跨ぎで移管できず、clasp トークンではゴミ箱送りすらできない(`drive.file` スコープ + スクリプトは Apps Script API 経由作成のため「アプリのファイル」扱いにならない)。対処: 正しいアカウントで `clasp login` → secret をローテーション → 各リポで `init.sh` 再実行 → 孤児スクリプトは旧所有者が手動削除。 |
 | GitLab ジョブが script 前に `id_tokens` エラーで失敗 | GitLab < 16.1(`aud` の変数展開)または < 15.7(`id_tokens` 自体)。アップグレードするか、旧テンプレ + legacy モードを継続。 |
 | GitLab で `main` は WIF が通るが `dev` で失敗 | `GCP_WIF_PROVIDER` / `CLASPRC_SECRET` が **protected** 変数になっている。unprotected に変更。 |
 | エアギャップ GitLab | WIF は `sts.googleapis.com` + `secretmanager.googleapis.com` への egress が必要。legacy `CLASPRC_JSON` を継続使用。 |

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -68,6 +68,12 @@ With the dedicated deploy Google account (e.g. `gas-deploy@yourcompany.com`):
 
 ```bash
 npx @google/clasp login            # writes ~/.clasprc.json
+
+# VERIFY the account before storing it — this file defines the fleet-wide
+# deploy identity, and a stale ~/.clasprc.json left over from earlier work
+# is easy to store by accident:
+node -e 'const rc=JSON.parse(require("fs").readFileSync(process.env.HOME+"/.clasprc.json","utf8"));const t=rc.tokens?.default??{client_id:rc.oauth2ClientSettings?.clientId,client_secret:rc.oauth2ClientSettings?.clientSecret,refresh_token:rc.token?.refresh_token};fetch("https://oauth2.googleapis.com/token",{method:"POST",headers:{"Content-Type":"application/x-www-form-urlencoded"},body:new URLSearchParams({client_id:t.client_id,client_secret:t.client_secret,refresh_token:t.refresh_token,grant_type:"refresh_token"})}).then(r=>r.json()).then(x=>fetch("https://www.googleapis.com/drive/v3/about?fields=user(emailAddress)",{headers:{Authorization:"Bearer "+x.access_token}})).then(r=>r.json()).then(w=>console.log("deploy account:",w.user?.emailAddress))'
+
 gcloud secrets create clasp-credentials --replication-policy=automatic
 gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"
 ```
@@ -209,6 +215,9 @@ Impossible under the legacy model; now routine:
 1. `clasp login` again with the deploy account, then
    `gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"`.
    CI reads `latest`, so this takes effect immediately — zero repo-side work.
+   Run the account-verification one-liner from §1 first — the same rotation
+   flow is also how you *replace* the deploy account, and storing the wrong
+   machine-local `~/.clasprc.json` silently changes the fleet's identity.
 2. Verify with any repo's dev deploy.
 3. `gcloud secrets versions disable <old>` → after a grace period
    `gcloud secrets versions destroy <old>`.
@@ -263,6 +272,7 @@ which the Apps Script API makes unavoidable.
 | Secret Manager 403 `PERMISSION_DENIED` (CI) — right after setup | `principalSet` IAM bindings take a few minutes to propagate. Wait 2–5 minutes and retry before changing anything. |
 | Secret Manager 403 `PERMISSION_DENIED` (CI) — persistent | Either the `principalSet` binding is missing/wrong (check the attribute name — `repository_owner` vs `namespace_path` — and value), **or the grant is on the secret resource only — move it to project level** (field-verified, see §4). |
 | `PERMISSION_DENIED` (developer) | Not in the developer Google group, or the group lacks `secretAccessor`. |
+| GAS scripts are owned by the wrong account | The secret was seeded from a stale machine-local `~/.clasprc.json`. Scripts cannot change owners across domains and the clasp token cannot even trash them (`drive.file` scope; scripts are created via the Apps Script API, so they are not "app files"). Fix: `clasp login` with the right account → rotate the secret → re-run `init.sh` per repo → the old owner deletes the orphaned scripts manually. |
 | GitLab job fails before script with `id_tokens` error | GitLab < 16.1 (variable expansion in `aud`) or < 15.7 (`id_tokens` itself). Upgrade or stay on legacy mode with an older template revision. |
 | WIF works on `main` but not `dev` (GitLab) | `GCP_WIF_PROVIDER` / `CLASPRC_SECRET` set as **protected** variables. Make them unprotected. |
 | Air-gapped GitLab | WIF needs egress to `sts.googleapis.com` + `secretmanager.googleapis.com`. Keep using legacy `CLASPRC_JSON`. |

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -56,8 +56,10 @@ GITLAB_URL=https://gitlab.example.com  # or https://gitlab.com
 gcloud config set project "$PROJECT_ID"
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
 
-# 0. Enable APIs
-gcloud services enable secretmanager.googleapis.com sts.googleapis.com iam.googleapis.com
+# 0. Enable APIs (cloudresourcemanager is used by the GitHub Action to
+#    resolve the project — without it the secret fetch fails at run time)
+gcloud services enable secretmanager.googleapis.com sts.googleapis.com \
+  iam.googleapis.com cloudresourcemanager.googleapis.com
 ```
 
 ### 1. Create the secret
@@ -69,6 +71,16 @@ npx @google/clasp login            # writes ~/.clasprc.json
 gcloud secrets create clasp-credentials --replication-policy=automatic
 gcloud secrets versions add clasp-credentials --data-file="$HOME/.clasprc.json"
 ```
+
+> If your organization enforces `constraints/gcp.resourceLocations`, the
+> `automatic` (global) replication is rejected with `FAILED_PRECONDITION`.
+> Pin the replica to an allowed region instead — resource name, access path,
+> and IAM are unchanged:
+>
+> ```bash
+> gcloud secrets create clasp-credentials \
+>   --replication-policy=user-managed --locations=asia-northeast1
+> ```
 
 ### 2. Create the WIF pool
 
@@ -118,6 +130,10 @@ gcloud secrets add-iam-policy-binding clasp-credentials \
   --member="principalSet://iam.googleapis.com/${POOL}/attribute.namespace_path/${GROUP}"
 ```
 
+> IAM changes on `principalSet://` members can take a few minutes to
+> propagate. A `PERMISSION_DENIED` on the very first CI run right after this
+> step usually just means "wait 2–5 minutes and retry", not a misconfiguration.
+
 ### 5. Grant developer access
 
 ```bash
@@ -153,7 +169,8 @@ org-wide grant.
 | `CLASPRC_SECRET` | `projects/<PROJECT_ID>/secrets/clasp-credentials` |
 
 - **GitHub**: Organization → Settings → Actions → Variables (not secrets —
-  these values are not sensitive).
+  these values are not sensitive). On a personal account (no org), set them
+  as repository variables instead.
 - **GitLab**: Group → Settings → CI/CD → Variables. Set them **unprotected**:
   protected variables are invisible on `dev` pipelines, which would silently
   drop dev deploys into legacy mode.
@@ -229,7 +246,10 @@ which the Apps Script API makes unavoidable.
 | STS 403 `unable to acquire impersonated credentials` / `The given credential is rejected by the attribute condition` | Provider `--attribute-condition` does not match (wrong org/group), or the JWT `aud` differs from `--allowed-audiences`. JWT `aud` = `$CI_SERVER_URL` with scheme, no trailing slash. |
 | STS 400 `Invalid value for "audience"` | STS request `audience` must be `//iam.googleapis.com/projects/<NUM>/…/providers/<name>` — **no `https:` prefix**, and it uses the project **number**. |
 | STS 400 `mapped attribute google.subject exceeds the 127 bytes limit` | The JWT `sub` is too long (deeply nested GitLab groups; long GitHub repo/environment names). Remap `google.subject` to a shorter claim, e.g. `assertion.project_path` (GitLab) — IAM here binds on attributes, not subject, so nothing else changes. |
-| Secret Manager 403 `PERMISSION_DENIED` (CI) | Missing/wrong `principalSet` binding. Verify the attribute name (`repository_owner` vs `namespace_path`) and value. |
+| `secrets create` fails with `FAILED_PRECONDITION` on `constraints/gcp.resourceLocations` | Org policy forbids global replication. Create with `--replication-policy=user-managed --locations=<allowed-region>` (check `gcloud org-policies describe gcp.resourceLocations --project=… --effective`). |
+| `cloud Resource Manager API has not been used in project …` during the CI secret fetch | Enable `cloudresourcemanager.googleapis.com` on the central project — `get-secretmanager-secrets` uses it to resolve the project. |
+| Secret Manager 403 `PERMISSION_DENIED` (CI) — right after setup | `principalSet` IAM bindings take a few minutes to propagate. Wait 2–5 minutes and retry before changing anything. |
+| Secret Manager 403 `PERMISSION_DENIED` (CI) — persistent | Missing/wrong `principalSet` binding. Verify the attribute name (`repository_owner` vs `namespace_path`) and value. |
 | `PERMISSION_DENIED` (developer) | Not in the developer Google group, or the group lacks `secretAccessor`. |
 | GitLab job fails before script with `id_tokens` error | GitLab < 16.1 (variable expansion in `aud`) or < 15.7 (`id_tokens` itself). Upgrade or stay on legacy mode with an older template revision. |
 | WIF works on `main` but not `dev` (GitLab) | `GCP_WIF_PROVIDER` / `CLASPRC_SECRET` set as **protected** variables. Make them unprotected. |

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -66,6 +66,12 @@ gcloud services enable secretmanager.googleapis.com sts.googleapis.com \
 
 With the dedicated deploy Google account (e.g. `gas-deploy@yourcompany.com`):
 
+First enable the **Apps Script API** for that account at
+[script.google.com/home/usersettings](https://script.google.com/home/usersettings)
+— it is a per-account setting, and `clasp create`/`push` fails with
+`User has not enabled the Apps Script API` without it (propagation can take
+a few minutes).
+
 ```bash
 npx @google/clasp login            # writes ~/.clasprc.json
 

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -118,21 +118,32 @@ sets to `$CI_SERVER_URL` (scheme included, no trailing slash).
 
 ### 4. Grant CI access (org/group-wide)
 
+Grant at the **project level**, not on the secret resource:
+
 ```bash
 POOL="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/gas-fleet"
 
-gcloud secrets add-iam-policy-binding clasp-credentials \
-  --role=roles/secretmanager.secretAccessor \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --role=roles/secretmanager.secretAccessor --condition=None \
   --member="principalSet://iam.googleapis.com/${POOL}/attribute.repository_owner/${ORG}"
 
-gcloud secrets add-iam-policy-binding clasp-credentials \
-  --role=roles/secretmanager.secretAccessor \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --role=roles/secretmanager.secretAccessor --condition=None \
   --member="principalSet://iam.googleapis.com/${POOL}/attribute.namespace_path/${GROUP}"
 ```
 
-> IAM changes on `principalSet://` members can take a few minutes to
+> **Field note — why project level:** granting `secretAccessor` to the
+> `principalSet://` on the secret alone (`gcloud secrets
+> add-iam-policy-binding`) was observed to keep returning `PERMISSION_DENIED`
+> for federated CI principals even 30+ minutes after binding, while the same
+> member granted at project level became effective within minutes. The central
+> project holds only fleet secrets, so the project-level grant does not widen
+> access in practice — but if you later add unrelated secrets to this project,
+> revisit this and re-test the secret-scoped grant.
+>
+> Also note: `principalSet://` IAM changes can take a few minutes to
 > propagate. A `PERMISSION_DENIED` on the very first CI run right after this
-> step usually just means "wait 2–5 minutes and retry", not a misconfiguration.
+> step usually just means "wait and retry".
 
 ### 5. Grant developer access
 
@@ -217,7 +228,8 @@ Impossible under the legacy model; now routine:
 
 ## Hardening: Per-Repo Grants (Optional)
 
-Instead of the org/group-wide `principalSet`, grant per repo:
+Instead of the org/group-wide `principalSet`, grant per repo (still at
+project level — see the field note in §4):
 
 ```bash
 # GitHub — one repo only
@@ -249,7 +261,7 @@ which the Apps Script API makes unavoidable.
 | `secrets create` fails with `FAILED_PRECONDITION` on `constraints/gcp.resourceLocations` | Org policy forbids global replication. Create with `--replication-policy=user-managed --locations=<allowed-region>` (check `gcloud org-policies describe gcp.resourceLocations --project=… --effective`). |
 | `cloud Resource Manager API has not been used in project …` during the CI secret fetch | Enable `cloudresourcemanager.googleapis.com` on the central project — `get-secretmanager-secrets` uses it to resolve the project. |
 | Secret Manager 403 `PERMISSION_DENIED` (CI) — right after setup | `principalSet` IAM bindings take a few minutes to propagate. Wait 2–5 minutes and retry before changing anything. |
-| Secret Manager 403 `PERMISSION_DENIED` (CI) — persistent | Missing/wrong `principalSet` binding. Verify the attribute name (`repository_owner` vs `namespace_path`) and value. |
+| Secret Manager 403 `PERMISSION_DENIED` (CI) — persistent | Either the `principalSet` binding is missing/wrong (check the attribute name — `repository_owner` vs `namespace_path` — and value), **or the grant is on the secret resource only — move it to project level** (field-verified, see §4). |
 | `PERMISSION_DENIED` (developer) | Not in the developer Google group, or the group lacks `secretAccessor`. |
 | GitLab job fails before script with `id_tokens` error | GitLab < 16.1 (variable expansion in `aud`) or < 15.7 (`id_tokens` itself). Upgrade or stay on legacy mode with an older template revision. |
 | WIF works on `main` but not `dev` (GitLab) | `GCP_WIF_PROVIDER` / `CLASPRC_SECRET` set as **protected** variables. Make them unprotected. |

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -211,6 +211,10 @@ org-wide grant.
     --body "projects/${PROJECT_ID}/secrets/clasp-credentials"
   ```
 
+  If `GH_TOKEN` is exported in your environment it overrides the stored
+  credential and blocks both `gh auth refresh` and the new scope — prefix
+  the commands with `env -u GH_TOKEN` in that case.
+
   On a personal account (no org), set them as repository variables instead.
 - **GitLab**: Group → Settings → CI/CD → Variables. Set them **unprotected**:
   protected variables are invisible on `dev` pipelines, which would silently

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -169,14 +169,23 @@ gcloud secrets add-iam-policy-binding clasp-credentials \
 
 **Off by default and billed** — required if you want per-access audit trails.
 In [IAM → Audit Logs](https://console.cloud.google.com/iam-admin/audit), enable
-**Data Read** for **Secret Manager API**, or via policy:
+**Data Read** for **Secret Manager API**, or scriptably (merges `DATA_READ`
+into the project IAM policy without clobbering existing audit configs):
 
-```yaml
-# gcloud projects get-iam-policy $PROJECT_ID > policy.yaml, add, then set-iam-policy
-auditConfigs:
-  - service: secretmanager.googleapis.com
-    auditLogConfigs:
-      - logType: DATA_READ
+```bash
+gcloud projects get-iam-policy "$PROJECT_ID" --format=json > /tmp/policy.json
+python3 - <<'EOF'
+import json
+p = json.load(open("/tmp/policy.json"))
+a = p.setdefault("auditConfigs", [])
+e = next((x for x in a if x.get("service") == "secretmanager.googleapis.com"), None)
+if e is None:
+    a.append({"service": "secretmanager.googleapis.com", "auditLogConfigs": [{"logType": "DATA_READ"}]})
+elif not any(c.get("logType") == "DATA_READ" for c in e.setdefault("auditLogConfigs", [])):
+    e["auditLogConfigs"].append({"logType": "DATA_READ"})
+json.dump(p, open("/tmp/policy.json", "w"), indent=2)
+EOF
+gcloud projects set-iam-policy "$PROJECT_ID" /tmp/policy.json
 ```
 
 Afterwards every `AccessSecretVersion` appears in Cloud Logging with the
@@ -192,8 +201,17 @@ org-wide grant.
 | `CLASPRC_SECRET` | `projects/<PROJECT_ID>/secrets/clasp-credentials` |
 
 - **GitHub**: Organization → Settings → Actions → Variables (not secrets —
-  these values are not sensitive). On a personal account (no org), set them
-  as repository variables instead.
+  these values are not sensitive), or via CLI — note the `admin:org` scope
+  (`gh auth refresh -h github.com -s admin:org` first if you get a 403):
+
+  ```bash
+  gh variable set GCP_WIF_PROVIDER --org "$ORG" --visibility all \
+    --body "projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/gas-fleet/providers/github"
+  gh variable set CLASPRC_SECRET --org "$ORG" --visibility all \
+    --body "projects/${PROJECT_ID}/secrets/clasp-credentials"
+  ```
+
+  On a personal account (no org), set them as repository variables instead.
 - **GitLab**: Group → Settings → CI/CD → Variables. Set them **unprotected**:
   protected variables are invisible on `dev` pipelines, which would silently
   drop dev deploys into legacy mode.


### PR DESCRIPTION
## Summary

amalfi-group での初の実環境ロールアウト(#41, #42 のフォローアップ)で踏んだ問題を docs に反映:

- **API 有効化に `cloudresourcemanager.googleapis.com` を追加** — `get-secretmanager-secrets` がプロジェクト解決に使用し、無いと実行時に失敗(実地で遭遇)
- **CI への付与は secret 単体ではなくプロジェクトレベルに変更** — secret スコープの principalSet 付与はバインディングから30分以上経っても `PERMISSION_DENIED` が継続、同一メンバーのプロジェクトレベル付与は数分で有効化(dev/prod 両デプロイで検証済み)。フィールドノートとして理由と再検討条件を明記
- **`constraints/gcp.resourceLocations` 対応** — automatic レプリケーションが拒否される組織向けに user-managed リージョン指定の代替手順を追記
- **IAM 伝播遅延・個人アカウント(org なし)での変数設定**をトラブルシューティング表に追加

## 検証

- [x] 全手順を amalfi-group + `amalfi-gas-fleet` プロジェクトで実地実行し、hello-world リポの dev / prod 両方が WIF 経由でデプロイ成功(GAS 側のデプロイメント実体も確認)
- [x] ドキュメントのみの変更(CI check への影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)