### PR TITLE
docs: add HTML sources for README diagrams

### DIFF
--- a/docs/diagrams/architecture.html
+++ b/docs/diagrams/architecture.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<!--
+  Source for docs/architecture.png (960x560).
+  Regenerate: ./docs/diagrams/render.sh
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        width: 960px;
+        height: 560px;
+        overflow: hidden;
+      }
+
+      body {
+        background: #0d1117;
+        font-family: 'DejaVu Sans Mono', monospace;
+        color: #e6edf3;
+        position: relative;
+      }
+
+      svg.wires {
+        position: absolute;
+        inset: 0;
+      }
+
+      .title {
+        position: absolute;
+        top: 22px;
+        left: 0;
+        width: 100%;
+        text-align: center;
+        font-size: 22px;
+        font-weight: bold;
+      }
+
+      .box {
+        position: absolute;
+        border-radius: 6px;
+        background: #10151d;
+      }
+
+      .template {
+        left: 374px;
+        top: 56px;
+        width: 212px;
+        height: 60px;
+        border: 1.5px solid #2f81f7;
+        border-left: 4px solid #2f81f7;
+        padding: 10px 12px;
+        white-space: nowrap;
+      }
+
+      .template .name {
+        color: #58a6ff;
+        font-weight: bold;
+        font-size: 14px;
+      }
+
+      .template .sub {
+        color: #8b949e;
+        font-size: 10px;
+        margin-top: 5px;
+        letter-spacing: 1px;
+      }
+
+      .hint {
+        position: absolute;
+        top: 124px;
+        left: 0;
+        width: 100%;
+        text-align: center;
+        color: #6e7681;
+        font-size: 10px;
+      }
+
+      .repo {
+        width: 196px;
+        height: 100px;
+        top: 172px;
+        padding: 12px 14px;
+      }
+
+      .repo .name {
+        font-weight: bold;
+        font-size: 13px;
+      }
+
+      .repo .desc {
+        color: #8b949e;
+        font-size: 11px;
+        line-height: 1.5;
+        margin-top: 8px;
+      }
+
+      .badges {
+        position: absolute;
+        left: 14px;
+        bottom: 12px;
+      }
+
+      .badge {
+        display: inline-block;
+        border-radius: 4px;
+        padding: 2px 7px;
+        font-size: 10px;
+        font-weight: bold;
+        color: #fff;
+        margin-right: 4px;
+      }
+
+      .ci {
+        background: #238636;
+      }
+
+      .cd {
+        background: #8957e5;
+      }
+
+      .section {
+        position: absolute;
+        left: 68px;
+        right: 68px;
+        color: #6e7681;
+        font-size: 10px;
+        letter-spacing: 0.5px;
+      }
+
+      .section::after {
+        content: '';
+        position: absolute;
+        left: 130px;
+        right: 0;
+        top: 6px;
+        border-top: 1px solid #21262d;
+      }
+
+      .infra {
+        top: 307px;
+        width: 400px;
+        height: 60px;
+        padding: 11px 14px;
+      }
+
+      .infra .name {
+        font-weight: bold;
+        font-size: 13px;
+      }
+
+      .infra .row {
+        margin-top: 7px;
+        font-size: 11px;
+      }
+
+      .infra .key {
+        font-size: 11px;
+      }
+
+      .infra .note {
+        color: #8b949e;
+        font-size: 10px;
+        margin-left: 12px;
+      }
+
+      .target {
+        position: absolute;
+        top: 420px;
+        height: 27px;
+        border: 1px solid #30363d;
+        border-radius: 5px;
+        background: #10151d;
+        color: #c9d1d9;
+        font-size: 11px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <svg class="wires" width="960" height="560">
+      <!-- template -> repos rail -->
+      <path
+        d="M480 116 V152 M165 152 H795 M165 152 V172 M375 152 V172 M585 152 V172 M795 152 V172"
+        stroke="#30363d"
+        stroke-width="1.5"
+        fill="none"
+      />
+      <circle cx="165" cy="152" r="3.5" fill="#484f58" />
+      <circle cx="375" cy="152" r="3.5" fill="#484f58" />
+      <circle cx="585" cy="152" r="3.5" fill="#484f58" />
+      <circle cx="795" cy="152" r="3.5" fill="#484f58" />
+      <!-- repos -> shared infra -->
+      <path
+        d="M165 272 V307 M375 272 V307 M585 272 V307 M795 272 V307"
+        stroke="#21262d"
+        stroke-width="1.5"
+        stroke-dasharray="3 4"
+        fill="none"
+      />
+      <!-- repos -> deploy targets -->
+      <path
+        d="M165 367 V420 M375 367 V420 M585 367 V420 M795 367 V420"
+        stroke="#21262d"
+        stroke-width="1.5"
+        stroke-dasharray="3 4"
+        fill="none"
+      />
+    </svg>
+
+    <div class="title">1 Repo = 1 Function</div>
+
+    <div class="box template">
+      <div class="name">apps-script-fleet</div>
+      <div class="sub">TypeScript&#8194;Rollup&#8194;Jest&#8194;CI/CD</div>
+    </div>
+    <div class="hint">Use this template</div>
+
+    <div class="box repo" style="left: 67px; border: 1.5px solid #3fb950">
+      <div class="name">slack-notify</div>
+      <div class="desc">Slack notification<br />on form submit</div>
+      <div class="badges">
+        <span class="badge ci">CI</span><span class="badge cd">CD</span>
+      </div>
+    </div>
+    <div class="box repo" style="left: 277px; border: 1.5px solid #2f81f7">
+      <div class="name">sheet-report</div>
+      <div class="desc">Weekly report<br />generation</div>
+      <div class="badges">
+        <span class="badge ci">CI</span><span class="badge cd">CD</span>
+      </div>
+    </div>
+    <div class="box repo" style="left: 487px; border: 1.5px solid #a371f7">
+      <div class="name">form-handler</div>
+      <div class="desc">Form response<br />processing</div>
+      <div class="badges">
+        <span class="badge ci">CI</span><span class="badge cd">CD</span>
+      </div>
+    </div>
+    <div class="box repo" style="left: 697px; border: 1.5px solid #d29922">
+      <div class="name">drive-cleanup</div>
+      <div class="desc">Drive file<br />auto-archiving</div>
+      <div class="badges">
+        <span class="badge ci">CI</span><span class="badge cd">CD</span>
+      </div>
+    </div>
+
+    <div class="section" style="top: 289px">Shared Infrastructure</div>
+
+    <div
+      class="box infra"
+      style="left: 68px; border: 1.5px solid #238636; background: #0f1d14"
+    >
+      <div class="name" style="color: #3fb950">Organization Secrets</div>
+      <div class="row">
+        <span class="key" style="color: #7ee787">CLASPRC_JSON</span>
+        <span class="note">shared across all repos</span>
+      </div>
+    </div>
+    <div
+      class="box infra"
+      style="left: 490px; border: 1.5px solid #8957e5; background: #16121f"
+    >
+      <div class="name" style="color: #bc8cff">Automated Maintenance</div>
+      <div class="row">
+        <span class="key" style="color: #d2a8ff">Renovate</span>
+        <span class="note">+ Template Sync</span>
+      </div>
+    </div>
+
+    <div class="section" style="top: 383px">Deploy Targets</div>
+
+    <div class="target" style="left: 76px">Apps Script Project A</div>
+    <div class="target" style="left: 286px">Apps Script Project B</div>
+    <div class="target" style="left: 496px">Apps Script Project C</div>
+    <div class="target" style="left: 706px">Apps Script Project D</div>
+  </body>
+</html>

--- a/docs/diagrams/before-after-human.html
+++ b/docs/diagrams/before-after-human.html
@@ -1,0 +1,327 @@
+<!doctype html>
+<!--
+  Source for docs/before-after-human.png (960x440).
+  Regenerate: ./docs/diagrams/render.sh
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        width: 960px;
+        height: 440px;
+        overflow: hidden;
+      }
+
+      body {
+        background: #0d1117;
+        font-family: 'DejaVu Sans Mono', monospace;
+        color: #e6edf3;
+        position: relative;
+      }
+
+      svg.scene {
+        position: absolute;
+        inset: 0;
+      }
+
+      .heading {
+        position: absolute;
+        top: 18px;
+        font-size: 16px;
+        font-weight: bold;
+      }
+
+      .chip {
+        position: absolute;
+        border-radius: 4px;
+        background: #10151d;
+        font-size: 10px;
+        padding: 4px 8px;
+      }
+
+      .vs {
+        position: absolute;
+        left: 461px;
+        top: 196px;
+        width: 38px;
+        height: 38px;
+        border: 1.5px solid #30363d;
+        border-radius: 50%;
+        background: #0d1117;
+        color: #6e7681;
+        font-size: 12px;
+        font-weight: bold;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .pill {
+        position: absolute;
+        border-radius: 10px;
+        font-size: 10px;
+        font-weight: bold;
+        padding: 3px 9px;
+      }
+
+      .fleetbar {
+        position: absolute;
+        left: 522px;
+        top: 318px;
+        width: 336px;
+        height: 24px;
+        border: 1.5px solid #238636;
+        border-radius: 5px;
+        background: #0f1d14;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 0 10px;
+        font-size: 8px;
+        color: #8b949e;
+        white-space: nowrap;
+      }
+
+      .fleetbar .name {
+        color: #7ee787;
+        font-weight: bold;
+        font-size: 10px;
+      }
+
+      .result {
+        position: absolute;
+        font-size: 20px;
+        font-weight: bold;
+      }
+
+      .result-sub {
+        position: absolute;
+        font-size: 11px;
+        color: #8b949e;
+      }
+    </style>
+  </head>
+  <body>
+    <svg class="scene" width="960" height="440">
+      <line
+        x1="480"
+        y1="10"
+        x2="480"
+        y2="430"
+        stroke="#21262d"
+        stroke-width="1.5"
+        stroke-dasharray="4 5"
+      />
+
+      <!-- left: overwhelmed developer -->
+      <g>
+        <!-- monitor -->
+        <rect
+          x="147"
+          y="84"
+          width="140"
+          height="108"
+          rx="6"
+          fill="#1c0d0f"
+          stroke="#57191d"
+          stroke-width="1.5"
+        />
+        <g stroke="#a12e33" stroke-width="4" stroke-linecap="round">
+          <line x1="158" y1="98" x2="252" y2="98" />
+          <line x1="158" y1="110" x2="228" y2="110" />
+          <line x1="158" y1="122" x2="262" y2="122" />
+          <line x1="158" y1="134" x2="214" y2="134" />
+          <line x1="158" y1="146" x2="244" y2="146" />
+          <line x1="158" y1="158" x2="200" y2="158" />
+          <line x1="158" y1="170" x2="236" y2="170" />
+        </g>
+        <rect x="209" y="192" width="16" height="14" fill="#21262d" />
+        <!-- person, arms thrown out -->
+        <circle cx="217" cy="205" r="14" fill="#6e7681" />
+        <path
+          d="M217 219 C202 222 196 236 196 252 L238 252 C238 236 232 222 217 219 Z"
+          fill="#6e7681"
+        />
+        <g stroke="#6e7681" stroke-width="7" stroke-linecap="round">
+          <line x1="200" y1="230" x2="172" y2="243" />
+          <line x1="234" y1="230" x2="262" y2="243" />
+        </g>
+        <!-- desk -->
+        <rect x="88" y="258" width="252" height="7" rx="2" fill="#21262d" />
+        <rect x="100" y="265" width="6" height="60" fill="#191f27" />
+        <rect x="322" y="265" width="6" height="60" fill="#191f27" />
+      </g>
+
+      <!-- right: pairing with CI, shipping -->
+      <g>
+        <!-- monitor -->
+        <rect
+          x="580"
+          y="78"
+          width="180"
+          height="122"
+          rx="6"
+          fill="#0d1f13"
+          stroke="#1c4428"
+          stroke-width="1.5"
+        />
+        <g stroke="#2ea043" stroke-width="4" stroke-linecap="round">
+          <line x1="592" y1="93" x2="740" y2="93" />
+          <line x1="592" y1="105" x2="700" y2="105" />
+          <line x1="592" y1="117" x2="748" y2="117" />
+          <line x1="592" y1="129" x2="676" y2="129" />
+          <line x1="592" y1="141" x2="728" y2="141" />
+          <line x1="592" y1="153" x2="662" y2="153" />
+          <line x1="592" y1="165" x2="712" y2="165" />
+          <line x1="592" y1="177" x2="688" y2="177" />
+        </g>
+        <rect x="662" y="200" width="16" height="12" fill="#21262d" />
+        <!-- relaxed developer -->
+        <circle cx="656" cy="196" r="13" fill="#6e7681" />
+        <path
+          d="M656 209 C643 212 638 224 638 238 L674 238 C674 224 669 212 656 209 Z"
+          fill="#6e7681"
+        />
+        <text
+          x="692"
+          y="196"
+          fill="#3fb950"
+          font-size="15"
+          font-family="DejaVu Sans Mono, monospace"
+        >
+          +
+        </text>
+        <!-- automation buddy with glowing head -->
+        <circle cx="740" cy="198" r="12" fill="#1f6feb" opacity="0.9" />
+        <circle
+          cx="740"
+          cy="198"
+          r="17"
+          fill="none"
+          stroke="#58a6ff"
+          stroke-width="1.5"
+          stroke-dasharray="2 5"
+        />
+        <line
+          x1="740"
+          y1="181"
+          x2="740"
+          y2="174"
+          stroke="#58a6ff"
+          stroke-width="2"
+        />
+        <circle cx="740" cy="172" r="2.5" fill="#58a6ff" />
+        <path
+          d="M740 210 C728 213 723 224 723 236 L757 236 C757 224 752 213 740 210 Z"
+          fill="#31445f"
+        />
+        <g stroke="#31445f" stroke-width="6" stroke-linecap="round">
+          <line x1="727" y1="222" x2="706" y2="232" />
+          <line x1="753" y1="222" x2="774" y2="232" />
+        </g>
+        <!-- desk -->
+        <rect x="548" y="262" width="264" height="7" rx="2" fill="#21262d" />
+        <rect x="560" y="269" width="6" height="46" fill="#191f27" />
+        <rect x="794" y="269" width="6" height="46" fill="#191f27" />
+      </g>
+    </svg>
+
+    <div class="heading" style="left: 40px; color: #f85149">
+      A developer's day
+    </div>
+    <div class="heading" style="left: 510px; color: #3fb950">
+      Same day, with Apps Script Fleet
+    </div>
+
+    <div
+      class="chip"
+      style="left: 44px; top: 60px; border: 1px solid #bb8009; color: #e3b341"
+    >
+      tsconfig
+    </div>
+    <div
+      class="chip"
+      style="left: 300px; top: 62px; border: 1px solid #bb8009; color: #e3b341"
+    >
+      rollup
+    </div>
+    <div
+      class="chip"
+      style="left: 36px; top: 141px; border: 1px solid #bb8009; color: #d29922"
+    >
+      eslint
+    </div>
+    <div
+      class="chip"
+      style="left: 306px; top: 149px; border: 1px solid #da3633; color: #ff7b72"
+    >
+      .clasp
+    </div>
+    <div
+      class="chip"
+      style="left: 48px; top: 217px; border: 1px solid #bb8009; color: #e3b341"
+    >
+      jest
+    </div>
+    <div
+      class="chip"
+      style="left: 310px; top: 219px; border: 1px solid #da3633; color: #ff7b72"
+    >
+      ci.yml
+    </div>
+    <div
+      class="chip"
+      style="left: 76px; top: 312px; border: 1px solid #da3633; color: #ff7b72"
+    >
+      cd.yml
+    </div>
+    <div
+      class="chip"
+      style="left: 272px; top: 310px; border: 1px solid #bb8009; color: #e3b341"
+    >
+      prettier
+    </div>
+
+    <div class="vs">vs</div>
+
+    <div
+      class="pill"
+      style="left: 556px; top: 244px; border: 1px solid #238636; color: #3fb950"
+    >
+      CI pass
+    </div>
+    <div
+      class="pill"
+      style="left: 632px; top: 244px; background: #8957e5; color: #fff"
+    >
+      CD deploy
+    </div>
+
+    <div class="fleetbar">
+      <span class="name">apps-script-fleet</span>
+      <span>TypeScript&#8194;CI/CD&#8194;Renovate&#8194;Template Sync</span>
+    </div>
+
+    <div class="result" style="left: 85px; top: 358px; color: #f85149">
+      30 min of real work
+    </div>
+    <div class="result-sub" style="left: 85px; top: 384px">
+      out of an 8-hour day
+    </div>
+
+    <div class="result" style="left: 560px; top: 358px; color: #3fb950">
+      2 projects shipped
+    </div>
+    <div class="result-sub" style="left: 560px; top: 384px">
+      in the same day
+    </div>
+  </body>
+</html>

--- a/docs/diagrams/before-after.html
+++ b/docs/diagrams/before-after.html
@@ -1,0 +1,340 @@
+<!doctype html>
+<!--
+  Source for docs/before-after.png (960x400).
+  Regenerate: ./docs/diagrams/render.sh
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        width: 960px;
+        height: 400px;
+        overflow: hidden;
+      }
+
+      body {
+        background: #0d1117;
+        font-family: 'DejaVu Sans Mono', monospace;
+        color: #e6edf3;
+        position: relative;
+      }
+
+      svg.wires {
+        position: absolute;
+        inset: 0;
+      }
+
+      .heading {
+        position: absolute;
+        top: 18px;
+        font-size: 18px;
+        font-weight: bold;
+      }
+
+      .chaos {
+        position: absolute;
+        border-radius: 6px;
+        background: #10151d;
+        padding: 9px 12px;
+        min-width: 100px;
+      }
+
+      .chaos .name {
+        font-weight: bold;
+        font-size: 13px;
+      }
+
+      .chaos .sub {
+        font-size: 10px;
+        margin-top: 12px;
+        color: #8b949e;
+      }
+
+      .vs {
+        position: absolute;
+        left: 461px;
+        top: 181px;
+        width: 38px;
+        height: 38px;
+        border: 1.5px solid #30363d;
+        border-radius: 50%;
+        background: #0d1117;
+        color: #6e7681;
+        font-size: 12px;
+        font-weight: bold;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .stamp {
+        position: absolute;
+        border-radius: 6px;
+        padding: 6px 14px;
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+      }
+
+      .stamp .big {
+        font-size: 24px;
+        font-weight: bold;
+      }
+
+      .stamp .small {
+        font-size: 12px;
+      }
+
+      .fleet {
+        position: absolute;
+        left: 635px;
+        top: 50px;
+        width: 160px;
+        height: 38px;
+        white-space: nowrap;
+        border: 1.5px solid #2f81f7;
+        border-left: 4px solid #2f81f7;
+        border-radius: 6px;
+        background: #0d1b2e;
+        color: #58a6ff;
+        font-weight: bold;
+        font-size: 13px;
+        display: flex;
+        align-items: center;
+        padding: 0 12px;
+      }
+
+      .tidy {
+        position: absolute;
+        width: 145px;
+        height: 34px;
+        border: 1.5px solid #238636;
+        border-radius: 6px;
+        background: #0f1d14;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 7px 0 9px;
+        white-space: nowrap;
+      }
+
+      .tidy .name {
+        font-weight: bold;
+        font-size: 11px;
+      }
+
+      .badge {
+        display: inline-block;
+        border-radius: 3px;
+        padding: 1px 3px;
+        font-size: 8px;
+        font-weight: bold;
+        color: #fff;
+      }
+
+      .ci {
+        background: #238636;
+      }
+
+      .cd {
+        background: #8957e5;
+      }
+
+      .orgbar {
+        position: absolute;
+        left: 570px;
+        top: 314px;
+        width: 276px;
+        height: 26px;
+        border: 1.5px solid #238636;
+        border-radius: 6px;
+        background: #0f1d14;
+        color: #7ee787;
+        font-size: 10px;
+        display: flex;
+        align-items: center;
+        padding: 0 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <svg class="wires" width="960" height="400">
+      <!-- tangled dependency lines on the chaos side -->
+      <g stroke="#57191d" stroke-width="1" opacity="0.7">
+        <line x1="113" y1="90" x2="318" y2="207" />
+        <line x1="145" y1="207" x2="260" y2="103" />
+        <line x1="87" y1="323" x2="370" y2="81" />
+        <line x1="207" y1="289" x2="145" y2="180" />
+        <line x1="318" y1="183" x2="87" y2="90" />
+        <line x1="260" y1="131" x2="340" y2="310" />
+        <line x1="37" y1="310" x2="207" y2="273" />
+      </g>
+      <line
+        x1="480"
+        y1="10"
+        x2="480"
+        y2="390"
+        stroke="#21262d"
+        stroke-width="1.5"
+        stroke-dasharray="4 5"
+      />
+      <!-- fleet -> repo grid -->
+      <path
+        d="M716 88 V104 M636 104 H796 M636 104 V115 M796 104 V115"
+        stroke="#30363d"
+        stroke-width="1.5"
+        fill="none"
+      />
+    </svg>
+
+    <div class="heading" style="left: 40px; color: #f85149">Without</div>
+    <div class="heading" style="left: 510px; color: #3fb950">
+      With Apps Script Fleet
+    </div>
+
+    <div
+      class="chaos"
+      style="left: 57px; top: 68px; border: 1.5px solid #da3633"
+    >
+      <div class="name" style="color: #ff7b72">slack-bot</div>
+      <div class="sub">no CI</div>
+    </div>
+    <div
+      class="chaos"
+      style="left: 205px; top: 92px; border: 1.5px solid #bb8009"
+    >
+      <div class="name" style="color: #e3b341">reports</div>
+      <div class="sub" style="color: #d29922">manual</div>
+    </div>
+    <div
+      class="chaos"
+      style="left: 310px; top: 55px; border: 1.5px solid #da3633"
+    >
+      <div class="name" style="color: #ffa198">sync-tool</div>
+      <div class="sub">yarn</div>
+    </div>
+    <div
+      class="chaos"
+      style="left: 85px; top: 183px; border: 1.5px solid #30363d"
+    >
+      <div class="name" style="color: #c9d1d9">forms</div>
+      <div class="sub" style="color: #f85149">broken</div>
+    </div>
+    <div
+      class="chaos"
+      style="left: 262px; top: 172px; border: 1.5px solid #da3633"
+    >
+      <div class="name" style="color: #ff7b72">cleanup</div>
+      <div class="sub">none</div>
+    </div>
+    <div
+      class="chaos"
+      style="left: 150px; top: 263px; border: 1.5px solid #30363d"
+    >
+      <div class="name" style="color: #c9d1d9">mailer</div>
+      <div class="sub">npm</div>
+    </div>
+    <div
+      class="chaos"
+      style="left: 280px; top: 282px; border: 1.5px solid #bb8009"
+    >
+      <div class="name" style="color: #e3b341">export</div>
+      <div class="sub">???</div>
+    </div>
+    <div
+      class="chaos"
+      style="left: 30px; top: 310px; border: 1.5px solid #21262d; opacity: 0.8"
+    >
+      <div class="name" style="color: #6e7681">dashboard</div>
+      <div class="sub" style="color: #484f58">pnpm</div>
+    </div>
+
+    <div
+      class="stamp"
+      style="
+        left: 60px;
+        top: 347px;
+        background: #4d1114;
+        border: 1.5px solid #da3633;
+      "
+    >
+      <span class="big" style="color: #ff7b72">2-4 hrs</span>
+      <span class="small" style="color: #ffa198">/ project</span>
+    </div>
+
+    <div class="vs">vs</div>
+
+    <div class="fleet">apps-script-fleet</div>
+
+    <div class="tidy" style="left: 565px; top: 115px">
+      <span class="name">slack-notify</span>
+      <span
+        ><span class="badge ci">CI</span> <span class="badge cd">CD</span></span
+      >
+    </div>
+    <div class="tidy" style="left: 715px; top: 115px">
+      <span class="name">sheet-report</span>
+      <span
+        ><span class="badge ci">CI</span> <span class="badge cd">CD</span></span
+      >
+    </div>
+    <div class="tidy" style="left: 565px; top: 163px">
+      <span class="name">form-handler</span>
+      <span
+        ><span class="badge ci">CI</span> <span class="badge cd">CD</span></span
+      >
+    </div>
+    <div class="tidy" style="left: 715px; top: 163px">
+      <span class="name">drive-cleanup</span>
+      <span
+        ><span class="badge ci">CI</span> <span class="badge cd">CD</span></span
+      >
+    </div>
+    <div class="tidy" style="left: 565px; top: 211px">
+      <span class="name">mailer</span>
+      <span
+        ><span class="badge ci">CI</span> <span class="badge cd">CD</span></span
+      >
+    </div>
+    <div class="tidy" style="left: 715px; top: 211px">
+      <span class="name">sync-tool</span>
+      <span
+        ><span class="badge ci">CI</span> <span class="badge cd">CD</span></span
+      >
+    </div>
+    <div class="tidy" style="left: 565px; top: 259px">
+      <span class="name">dashboard</span>
+      <span
+        ><span class="badge ci">CI</span> <span class="badge cd">CD</span></span
+      >
+    </div>
+    <div class="tidy" style="left: 715px; top: 259px">
+      <span class="name">export</span>
+      <span
+        ><span class="badge ci">CI</span> <span class="badge cd">CD</span></span
+      >
+    </div>
+
+    <div class="orgbar">Org Secrets + Renovate + Template Sync</div>
+
+    <div
+      class="stamp"
+      style="
+        left: 800px;
+        top: 347px;
+        background: #0f2c17;
+        border: 1.5px solid #238636;
+      "
+    >
+      <span class="big" style="color: #3fb950">5 min</span>
+    </div>
+  </body>
+</html>

--- a/docs/diagrams/render.sh
+++ b/docs/diagrams/render.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Render docs/*.png from the HTML sources in this directory.
+# Requires a Chromium/Chrome binary (override with CHROMIUM=/path/to/chromium).
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Prefer a headless-shell build: regular Chromium subtracts window chrome from
+# --window-size even in headless mode, clipping the bottom of the page.
+find_chromium() {
+  local hs
+  hs=$(find /opt/pw-browsers -maxdepth 3 -type f \( -name headless_shell -o -name chrome-headless-shell \) 2>/dev/null | head -1)
+  if [ -n "$hs" ]; then echo "$hs"; return; fi
+  command -v chrome-headless-shell || command -v chromium || command -v chromium-browser || command -v google-chrome || echo /opt/pw-browsers/chromium
+}
+CHROMIUM="${CHROMIUM:-$(find_chromium)}"
+
+render() {
+  local name="$1" size="$2"
+  "$CHROMIUM" --headless --no-sandbox --disable-gpu --hide-scrollbars \
+    --force-device-scale-factor=1 --window-size="$size" \
+    --screenshot="../$name.png" "file://$PWD/$name.html" 2>/dev/null
+  echo "rendered ../$name.png ($size)"
+}
+
+render architecture 960,560
+render before-after 960,400
+render before-after-human 960,440


### PR DESCRIPTION
## Summary

The three README diagrams (`docs/architecture.png`, `docs/before-after.png`, `docs/before-after-human.png`) previously existed only as PNGs — every edit meant redrawing from scratch. This adds their HTML/CSS+SVG sources plus a `render.sh` under `docs/diagrams/` so future changes only require editing the HTML and re-rendering.

- `render.sh` screenshots each HTML at the exact PNG dimensions via headless Chromium. It prefers a headless-shell binary because regular Chromium subtracts window chrome from `--window-size` even in headless mode, clipping the bottom of the capture.
- The sources reproduce the current images byte-for-byte when rendered in the same environment (verified against the PNGs in #44).

Companion to #44, which regenerates the PNGs themselves with the new `apps-script-fleet` naming — the sources here already use that naming, so this is best merged after #44.

## Verification
- `pnpm run check` passes (stylelint/htmlhint cover the new HTML)
- `./docs/diagrams/render.sh` reproduces the three PNGs from #44 byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuYAJwrp38iqmRuXw2MsAW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuYAJwrp38iqmRuXw2MsAW)_